### PR TITLE
Applies minor updates to the Helm values and chatbot proxy configuration

### DIFF
--- a/helm-charts/files/chatbot-service-proxy.conf
+++ b/helm-charts/files/chatbot-service-proxy.conf
@@ -1,10 +1,14 @@
+{{- $backend := required "The backend URL is required!" .Values.configuration.backend.url -}}
+{{- $backendUrl := urlParse $backend -}}
 server {
   listen 8080;
+  server_name localhost {{ $backendUrl.hostname }};
 
   # Proxies the request for the Chatbot service to the correct address.
-  location = /rest/ {
+  location /rest/ {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_pass {{ printf "%s/rest/" (required "The backend URL is required!" .Values.configuration.backend.url) }};
+    set $upstream {{ printf "%s/rest/" $backend }};
+    proxy_pass $upstream;
   }
 }

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -75,7 +75,7 @@ image:
   registry: ghcr.io
 
   # The repository name of the application image.
-  repository: statnett/Talk2PowerSystem_UI
+  repository: statnett/talk2powersystem_ui
 
   # Image tag that corresponds to the version of application.
   # By default, the chart uses .Chart.AppVersion to construct the full image name.


### PR DESCRIPTION
- Updated the name of the docker image that is used in the chart. When the pipeline creates an image name it lowers the casing from the repository name.

- Updated the chatbot proxt configuration to include server name in order to avoid duplications, which leads to ignoring the config.

  Also fixed the startup of the container, if the domain to which the
requests are proxied, isn't available.