### PR TITLE
Fixes "Open in SPARQL editor" link

### DIFF
--- a/src/directives/chat/chat-item-details/chat-item-detail.directive.html
+++ b/src/directives/chat/chat-item-details/chat-item-detail.directive.html
@@ -64,7 +64,6 @@
                                 <div ng-if="queryMethod.query" class="actions">
                                     <open-in-sparql-editor
                                         ng-if="queryMethod.queryType === ExplainQueryType.SPARQL"
-                                        execute-query="{{!queryMethod.errorMessage}}"
                                         repository-id="{{repositoryId}}"
                                         query="{{queryMethod.query}}">
                                     </open-in-sparql-editor>

--- a/src/directives/core/open-in-sparql-editor/open-in-sparql-editor.directive.html
+++ b/src/directives/core/open-in-sparql-editor/open-in-sparql-editor.directive.html
@@ -1,5 +1,5 @@
 <a class="btn btn-link btn-sm open-in-sparql-editor-btn"
-   href="sparql?query={{query}}&execute={{executeQuery}}"
+   href="graphdb/sparql?query={{query}}&execute={{executeQuery}}"
    target="_blank"
    tt2ps-tooltip="{{'chat_panel.btn.open_in_sparql_editor.tooltip' | translate}}">
     <i class="fa fa-bracket-curly"></i>

--- a/src/directives/core/open-in-sparql-editor/open-in-sparql-editor.directive.js
+++ b/src/directives/core/open-in-sparql-editor/open-in-sparql-editor.directive.js
@@ -42,6 +42,11 @@ function OpenInSparqlEditorDirective() {
         scope: {
             query: '@',
             executeQuery: '@'
+        },
+        link: function($scope) {
+            if (!$scope.executeQuery) {
+                $scope.executeQuery = false;
+            }
         }
     };
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -7,4 +7,5 @@
 @use './scss/partials/media';
 @use './scss/partials/alert';
 @use './scss/partials/toast';
+@use './scss/partials/icons';
 @import "~angular-toastr/dist/angular-toastr.min.css";

--- a/src/styles/scss/partials/_buttons.scss
+++ b/src/styles/scss/partials/_buttons.scss
@@ -50,4 +50,5 @@
   color: var(--primary-color);
   padding: .5em .8em;
   background-color: transparent;
+  text-decoration: none;
 }

--- a/src/styles/scss/partials/_icons.scss
+++ b/src/styles/scss/partials/_icons.scss
@@ -1,0 +1,8 @@
+.fa, .fa-regular, .fa-light, .fa-thin {
+  /*
+  General fix for FontAwesome icons being somewhat larger than our icons font.
+  font-size-adjust has other ways to do this (ex-height N) but that doesn't work well
+  with this font in Firefox. This magic value works identically in all browsers.
+  */
+  font-size-adjust: ch-width 0.52;
+}


### PR DESCRIPTION
## What
When clicking on the "Open in SPARQL editor" link, the chat page opens instead of the SPARQL editor.

## Why
The link’s href was incorrect. It tries to open the SPARQL editor on the server where the app is deployed, but the GraphDB instance actually runs under the 'graphdb' context.

## How
- Updated the href attribute to include the correct GraphDB instance context;
- Changed the executeQuery parameter to false. This will prevent automatic execution of the query;
- Fixed the styling of the 'Open in SPARQL editor' link.