### PR TITLE
Manage user sessions in the Chatbot UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@azure/msal-browser": "^4.19.0",
         "angular": "^1.8.3",
         "angular-route": "^1.8.3",
         "angular-toastr": "^2.1.1",
@@ -38,6 +39,25 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.19.0.tgz",
+      "integrity": "sha512-g6Ea+sJmK7l5NUyrPhtD7DNj/tZcsr6VTNNLNuYs8yPvL3HNiIpO/0kzXntF9AqJ/6L+uz9aHmoT1x+RNq6zBQ==",
+      "dependencies": {
+        "@azure/msal-common": "15.10.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "15.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.10.0.tgz",
+      "integrity": "sha512-+cGnma71NV3jzl6DdgdHsqriN4ZA7puBIzObSYCvcIVGMULGb2NrcOGV6IJxO06HoVRHFKijkxd9lcBvS063KQ==",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
+    "@azure/msal-browser": "^4.19.0",
     "angular": "^1.8.3",
     "angular-route": "^1.8.3",
     "angular-toastr": "^2.1.1",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3,6 +3,30 @@
     "title": "Talk to Power System",
     "footer": {
       "security_disclaimer": "This is a demo version and we cannot guarantee the accuracy of results, nor the availability or security of the system. Please don't include any kind of sensitive data in your questions"
+    },
+    "login-errors": {
+      "popup_window_error": "Error opening popup window. This can happen if popups are blocked in your browser. <br>Please enable popups for this site and try again.",
+      "user_cancelled": "Sign-in was cancelled."
+    },
+    "login": {
+      "already_logged_in": "You are already signed in",
+      "you_are_already_logged_in": "You are authenticated and can use the chatbot.",
+      "go_to_chatbot": "Go to Chatbot",
+      "logout": "Sign out",
+      "not_logged_in": "You are not signed in",
+      "login_required": "Please sign in before using the Talk to Power System chatbot.",
+      "security_not_enabled": "Security is not enabled",
+      "security_not_enabled_description": "You can access the chatbot directly without signing in."
+    }
+  },
+  "header": {
+    "btn": {
+      "logout": {
+        "label": "Sign out"
+      },
+      "login": {
+        "label": "Sign in"
+      }
     }
   },
   "chat_panel": {

--- a/src/configurations/app-configurations.js
+++ b/src/configurations/app-configurations.js
@@ -1,0 +1,1 @@
+export const DEVELOPMENT = false;

--- a/src/directives/chat/chat-item-details/chat-item-detail.directive.js
+++ b/src/directives/chat/chat-item-details/chat-item-detail.directive.js
@@ -16,7 +16,7 @@ const ChatItemDetailModule = angular
     .module('tt2ps.directives.chat.chat-item-detail', modules)
     .directive('chatItemDetail', ChatItemDetailDirective);
 
-ChatItemDetailDirective.$inject = ['toastr', '$translate', 'ChatContextService', 'ChatService', '$filter'];
+ChatItemDetailDirective.$inject = ['ToastrService', '$translate', 'ChatContextService', 'ChatService', '$filter'];
 
 /**
  * @ngdoc directive
@@ -90,9 +90,9 @@ function ChatItemDetailDirective(toastr, $translate, ChatContextService, ChatSer
                             if (error.status === 400) {
                                 ChatContextService.emit(ChatContextEventName.CONVERSATION_EXPIRED);
                             } else if (error.status === 422) {
-                                toastr.error($translate.instant('chat_panel.error.unprocessable_entity'));
+                                ToastrService.error($translate.instant('chat_panel.error.unprocessable_entity'));
                             } else {
-                                toastr.error($translate.instant('chat_panel.messages.explain_response_failure'));
+                                ToastrService.error($translate.instant('chat_panel.messages.explain_response_failure'));
                             }
                         })
                         .finally(() => $scope.loadingExplainResponse[messageId] = false);

--- a/src/directives/chat/chat-panel/chat-panel.directive.js
+++ b/src/directives/chat/chat-panel/chat-panel.directive.js
@@ -9,7 +9,6 @@ import ChatItemDetailModule from '../chat-item-details/chat-item-detail.directiv
 import ChatQuestionListModule from "../chat-question-list/chat-question-list.directive";
 
 let modules = [
-    'toastr',
     ChatContextServiceModule.name,
     ChatItemDetailModule.name,
     ChatQuestionListModule.name
@@ -17,7 +16,7 @@ let modules = [
 const chatPanelModule = angular.module('tt2ps.components.chat.chat-panel', modules);
 chatPanelModule.directive('chatPanel', ChatPanelDirective);
 
-ChatPanelDirective.$inject = ['toastr', '$translate', 'ChatContextService'];
+ChatPanelDirective.$inject = ['$translate', 'ChatContextService'];
 
 /**
  * @ngdoc directive
@@ -29,7 +28,7 @@ ChatPanelDirective.$inject = ['toastr', '$translate', 'ChatContextService'];
  * @example
  * <chat-panel></chat-panel>
  */
-function ChatPanelDirective(toastr, $translate, ChatContextService) {
+function ChatPanelDirective($translate, ChatContextService) {
 
     return {
         template,

--- a/src/directives/chat/chat-question-list/chat-question-list.directive.scss
+++ b/src/directives/chat/chat-question-list/chat-question-list.directive.scss
@@ -6,6 +6,7 @@
   overflow-x: hidden;
   padding: 0.5rem;
   background-color: var(--base-background-color);
+  height: 100%;
 
   .question-item {
     border: none;

--- a/src/directives/core/copy-to-clipboard/copy-to-clipboard.directive.js
+++ b/src/directives/core/copy-to-clipboard/copy-to-clipboard.directive.js
@@ -4,7 +4,7 @@ import template from './copy-to-clipboard.directive.html';
 const CopyToClipboardModule = angular.module('tt2ps.directives.core.copy-to-clipboard.copy-to-clipboard', []);
 CopyToClipboardModule.directive('copyToClipboard', CopyToClipboardDirective);
 
-CopyToClipboardDirective.$inject = ['$translate', 'toastr'];
+CopyToClipboardDirective.$inject = ['$translate', 'ToastrService'];
 
 /**
  * @ngdoc directive
@@ -45,7 +45,7 @@ CopyToClipboardDirective.$inject = ['$translate', 'toastr'];
  *   </copy-to-clipboard>
  * </div>
  */
-function CopyToClipboardDirective($translate, toastr) {
+function CopyToClipboardDirective($translate, ToastrService) {
     return {
         template,
         restrict: 'E',
@@ -101,7 +101,7 @@ function CopyToClipboardDirective($translate, toastr) {
                 if ($scope.customTooltipStyle) {
                     showCustomTooltip();
                 } else {
-                    toastr.success($translate.instant('copy_to_clipboard.messages.copied_to_clipboard'));
+                    ToastrService.success($translate.instant('copy_to_clipboard.messages.copied_to_clipboard'));
                 }
             }
 

--- a/src/directives/core/login-button/login-button.html
+++ b/src/directives/core/login-button/login-button.html
@@ -1,0 +1,4 @@
+<button class="btn login"
+        ng-click="login()">
+    {{'header.btn.login.label' | translate}}
+</button>

--- a/src/directives/core/login-button/login-button.js
+++ b/src/directives/core/login-button/login-button.js
@@ -1,0 +1,59 @@
+import template from './login-button.html';
+import AuthenticationModule from "../../../services/security/authentication.service";
+import {UserModel} from "../../../models/security/user";
+import {AuthenticationState} from "../../../models/security/authentication-state";
+
+const dependencies = [
+    AuthenticationModule.name
+];
+const LoginButtonModule = angular.module('tt2ps.directives.core.logout-button', dependencies);
+
+LoginButtonModule.directive('loginButton', LoginButtonDirective);
+
+LoginButtonDirective.$inject = ['$translate', 'ToastrService', 'SecurityContextService', 'AuthenticationService']
+
+/**
+ * Directive for rendering a login button. When clicked, it triggers the authentication process.
+ */
+function LoginButtonDirective($translate, ToastrService, SecurityContextService, AuthenticationService) {
+    return {
+        restrict: 'E',
+        template,
+        scope: {},
+        link: function (scope) {
+
+            // =========================
+            // Public functions
+            // =========================
+            scope.login = () => {
+                AuthenticationService.login()
+                    .then(updateAuthenticatedUser)
+                    .catch((err) => {
+                        const errorLabelKey = `tt2ps.login-errors.${err.errorCode}`;
+                        const errorMessage = $translate.instant(errorLabelKey);
+                        if (errorMessage !== errorLabelKey) {
+                            ToastrService.error(errorMessage);
+                        } else {
+                            ToastrService.error(err.message || err.errorMessage);
+                        }
+                        SecurityContextService.updateAuthenticationState(AuthenticationState.NOT_AUTHENTICATED);
+                        throw err;
+                    })
+            }
+
+            // =========================
+            // Private functions
+            // =========================
+            const updateAuthenticatedUser = (activeUserAccount) => {
+                const user = new UserModel({
+                    username: activeUserAccount.username,
+                    name: activeUserAccount.name
+                });
+                SecurityContextService.updateAuthenticatedUser(user);
+            }
+        }
+    }
+}
+
+export default LoginButtonModule;
+

--- a/src/directives/core/logout-button/logout-button.html
+++ b/src/directives/core/logout-button/logout-button.html
@@ -1,0 +1,4 @@
+<button class="btn logout btn-primary"
+        ng-click="logout()">
+    {{'header.btn.logout.label' | translate}}
+</button>

--- a/src/directives/core/logout-button/logout-button.js
+++ b/src/directives/core/logout-button/logout-button.js
@@ -1,0 +1,32 @@
+import './logout-button.scss';
+import template from './logout-button.html';
+import AuthenticationModule from "../../../services/security/authentication.service";
+
+const dependencies = [
+    AuthenticationModule.name
+];
+const LogoutButtonModule = angular.module('tt2ps.directives.core.logout-button', dependencies);
+
+LogoutButtonModule.directive('logoutButton', LogoutButtonDirective);
+
+LogoutButtonDirective.$inject = ['SecurityService', 'AuthenticationService']
+
+/**
+ * Directive for rendering a logout button. When clicked, it triggers the logout process.
+ */
+function LogoutButtonDirective(SecurityService, AuthenticationService) {
+    return {
+        restrict: 'E',
+        template,
+        link: function ($scope) {
+            // =========================
+            // Public functions
+            // =========================
+
+            $scope.logout = AuthenticationService.logout;
+        }
+    }
+}
+
+export default LogoutButtonModule;
+

--- a/src/directives/core/logout-button/logout-button.scss
+++ b/src/directives/core/logout-button/logout-button.scss
@@ -1,0 +1,4 @@
+.logout {
+  width: 100%;
+  text-align: left;
+}

--- a/src/directives/tt2ps-header/tt2ps-header.directive.html
+++ b/src/directives/tt2ps-header/tt2ps-header.directive.html
@@ -1,3 +1,7 @@
 <div class="header">
-    <h1>{{'tt2ps.title' | translate}}</h1>
+    <img class="statnett-logo" src="images/statnett-logo-primary-green.svg" alt="Statnett company logo"/>
+    <h1 class="title">{{'tt2ps.title' | translate}}</h1>
+    <div class="right-menu">
+        <user-menu ng-if="showUserMenu"></user-menu>
+    </div>
 </div>

--- a/src/directives/tt2ps-header/tt2ps-header.directive.js
+++ b/src/directives/tt2ps-header/tt2ps-header.directive.js
@@ -1,15 +1,117 @@
 import './tt2ps-header.directive.scss';
 import template from './tt2ps-header.directive.html';
+import SecurityContextServiceModule from "../../services/security/security-context.service";
+import UserMenuModule from "../user-menu/user-menu.directive";
 
-const HeaderModule = angular.module('tt2ps.components.header', []);
+const dependencies = [
+    SecurityContextServiceModule.name,
+    UserMenuModule.name
+];
+const HeaderModule = angular.module('tt2ps.components.header', dependencies);
 
 HeaderModule.directive('tt2psHeader', Tt2psHeaderDirective);
 
-function Tt2psHeaderDirective() {
+Tt2psHeaderDirective.$inject = ['SecurityContextService'];
+
+/**
+ * Directive for rendering the TT2PS header.
+ */
+function Tt2psHeaderDirective(SecurityContextService) {
     return {
         restrict: 'E',
         template,
-        link: () => {},
+        link: ($scope) => {
+
+            // =========================
+            // Public variables
+            // =========================
+
+            /**
+             * Determines whether the user menu should be displayed.
+             * @type {boolean}
+             */
+            $scope.showUserMenu = false;
+
+            // =========================
+            // Private variables
+            // =========================
+
+            /**
+             * Current security configuration.
+             * @type {SecurityConfigurationModel|undefined}
+             */
+            let securityConfig = undefined;
+
+            /**
+             * Currently authenticated user.
+             * @type {UserModel|undefined}
+             */
+            let authenticatedUser = undefined;
+
+            /**
+             * Array of subscription functions to unsubscribe from when the header is destroyed.
+             * @type {*[]}
+             */
+            const subscriptions = [];
+
+            // =========================
+            // Private functions
+            // =========================
+
+            /**
+             * Initializes the directive.
+             */
+            const init = () => {
+                updateShowUserMenu();
+            }
+
+            /**
+             * Updates `$scope.showUserMenu` based on the current security configuration and user.
+             */
+            const updateShowUserMenu = () => {
+                $scope.showUserMenu = securityConfig && securityConfig.enabled && authenticatedUser;
+            }
+
+            /**
+             * Handles updates to the security configuration.
+             * @param {SecurityConfigurationModel} securityConfiguration - The updated security configuration.
+             */
+            const onSecurityConfigurationChanged = (securityConfiguration) => {
+                securityConfig = securityConfiguration;
+                updateShowUserMenu();
+            }
+
+            /**
+             * Handles updates to the authenticated user.
+             * @param {UserModel} user - The updated authenticated user.
+             */
+            const onAuthenticatedUserChanged = (user) => {
+                authenticatedUser = user;
+                updateShowUserMenu();
+            }
+
+            /**
+             * Removes all registered subscriptions.
+             */
+            const removeAllSubscribers = () => {
+                subscriptions.forEach((subscription) => subscription());
+            };
+
+            // =========================
+            // Subscriptions
+            // =========================
+
+            subscriptions.push(SecurityContextService.onSecurityConfigurationChanged(onSecurityConfigurationChanged));
+            subscriptions.push(SecurityContextService.onAuthenticatedUserChanged(onAuthenticatedUserChanged));
+
+            // Deregister the watcher when the scope/directive is destroyed
+            $scope.$on('$destroy', removeAllSubscribers);
+
+            // =========================
+            // Initialization
+            // =========================
+            init();
+        },
     };
 }
 

--- a/src/directives/tt2ps-header/tt2ps-header.directive.scss
+++ b/src/directives/tt2ps-header/tt2ps-header.directive.scss
@@ -1,3 +1,21 @@
 .header {
-  text-align: center;
+  display: flex;
+  justify-content: space-between;
+
+  .statnett-logo {
+    display: block;
+    max-height: 2rem;
+    padding-top: 1rem;
+    padding-left: 1rem;
+  }
+
+  .title {
+    padding-top: 1rem;
+  }
+
+  .right-menu {
+    min-width: 100px;
+    display: flex;
+    justify-content: flex-end;
+  }
 }

--- a/src/directives/user-menu/user-menu.directive.html
+++ b/src/directives/user-menu/user-menu.directive.html
@@ -1,0 +1,12 @@
+<div ng-if="authenticatedUser" class="user-menu" ng-class="{'expanded': menuOpen}">
+    <div class="user-menu-toggle" ng-click="toggleMenu($event)">
+        <i class="user-icon fa-solid fa-user"></i>
+        <span class="username">{{authenticatedUser.username }}</span>
+        <i class="dropdown-icon fa-light fa-angle-down"></i>
+    </div>
+    <ul class="user-menu-dropdown" ng-if="menuOpen">
+        <li class="menu-item">
+            <logout-button></logout-button>
+        </li>
+    </ul>
+</div>

--- a/src/directives/user-menu/user-menu.directive.js
+++ b/src/directives/user-menu/user-menu.directive.js
@@ -1,0 +1,122 @@
+import './user-menu.directive.scss';
+import template from './user-menu.directive.html';
+import LogoutButtonModule from "../core/logout-button/logout-button";
+
+const dependencies = [
+    LogoutButtonModule.name
+];
+const UserMenuModule = angular.module('tt2ps.directives.user-menu', dependencies);
+
+UserMenuModule.directive('userMenu', UserMenu);
+
+UserMenu.$inject = ['SecurityContextService', '$document']
+
+/**
+ * @ngdoc directive
+ * @name userMenu
+ * @module tt2ps.directives.user-menu
+ * @restrict E
+ *
+ * @description
+ * The `userMenu` directive renders a user dropdown menu.
+ * When the user is authenticated, it shows their name/username, and provides a dropdown
+ * with options such as logout.
+ *
+ * @example
+ * <user-menu></user-menu>
+ */
+function UserMenu(SecurityContextService, $document) {
+    return {
+        restrict: 'E',
+        template,
+        link: function ($scope) {
+
+            // =========================
+            // Public variables
+            // =========================
+
+            /**
+             * The currently authenticated user, updated via SecurityContextService subscription.
+             *
+             * @type {UserModel|undefined}
+             */
+            $scope.authenticatedUser;
+
+            /**
+             * Whether the dropdown menu is currently open.
+             *
+             * @type {boolean}
+             */
+            $scope.menuOpen = false;
+
+            // =========================
+            // Private variables
+            // =========================
+
+            /**
+             * Array of subscription functions to unsubscribe from when the directive is destroyed.
+             * @type {*[]}
+             */
+            const subscriptions = [];
+
+            // =========================
+            // Public functions
+            // =========================
+
+            /**
+             * Toggles the visibility of the user menu dropdown.
+             */
+            $scope.toggleMenu = () => {
+                $scope.menuOpen = !$scope.menuOpen;
+            }
+
+            // =========================
+            // Private functions
+            // =========================
+
+            /**
+             * Updates the authenticated user.
+             *
+             * @param {UserModel|undefined} user - The updated authenticated user.
+             */
+            const onAuthenticatedUserChanged = (user) => {
+                $scope.authenticatedUser = user;
+            }
+
+            /**
+             * Handles global click events to close the menu when clicking outside the toggle.
+             */
+            const clickHandler = (event) => {
+                if ($scope.menuOpen) {
+                    // Skip if the click was on the toggle element
+                    const isToggleClicked = event.target.closest('.user-menu-toggle') !== null;
+                    if (!isToggleClicked) {
+                        $scope.$apply(() => {
+                            $scope.menuOpen = false;
+                        });
+                    }
+                }
+            };
+
+            /**
+             * Removes all active subscriptions and event listeners when the directive is destroyed.
+             */
+            const removeAllSubscribers = () => {
+                subscriptions.forEach((subscription) => subscription());
+                $document.off('click', clickHandler);
+            };
+
+            // =========================
+            // Subscriptions
+            // =========================
+
+            $document.on('click', clickHandler);
+            subscriptions.push(SecurityContextService.onAuthenticatedUserChanged(onAuthenticatedUserChanged));
+            // Deregister the watcher when the scope/directive is destroyed
+            $scope.$on('$destroy', removeAllSubscribers);
+        }
+    }
+}
+
+export default UserMenuModule;
+

--- a/src/directives/user-menu/user-menu.directive.scss
+++ b/src/directives/user-menu/user-menu.directive.scss
@@ -1,0 +1,67 @@
+.user-menu {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+
+  &.expanded {
+    color: white;
+
+    .user-menu-toggle {
+      background: var(--primary-color);
+
+      &:hover {
+        background: var(--primary-color);
+      }
+
+      .dropdown-icon {
+        transform: rotate(180deg);
+      }
+
+      .user-icon {
+        color: white;
+      }
+    }
+  }
+
+  .user-menu-toggle {
+    padding: 8px 12px;
+    background: var(--base-dropdown-color);
+    display: flex;
+    align-items: center;
+    max-width: 20rem;
+    gap: 6px;
+    cursor: pointer;
+
+
+    &:hover {
+      background: var(--base-dropdown-hovered-color);
+    }
+    .user-icon {
+      padding-right: 5px;
+      color: var(--primary-color);
+    }
+
+    .username {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .user-menu-dropdown {
+    background-color: var(--primary-color);
+    position: absolute;
+    list-style: none;
+    margin: 0;
+    z-index: 1000;
+    padding: 0;
+    width: 100%;
+
+    .menu-item {
+      *:hover {
+        background-color: var(--primary-color-dark);
+      }
+      cursor: pointer;
+    }
+  }
+}

--- a/src/interceptors/authentication.interceptor.js
+++ b/src/interceptors/authentication.interceptor.js
@@ -1,0 +1,36 @@
+const AuthenticationInterceptorModule = angular.module('tt2ps.interceptors.authentication', []);
+
+AuthenticationInterceptorModule.factory('AuthenticationInterceptor', AuthenticationInterceptor);
+
+AuthenticationInterceptor.$inject = ['SecurityContextService', 'AuthenticationService'];
+
+/**
+ * Intercepts HTTP requests to add authentication headers.
+ */
+function AuthenticationInterceptor(SecurityContextService, AuthenticationService) {
+    let securityEnabled = false;
+
+    SecurityContextService.onSecurityConfigurationChanged(
+        (securityConfiguration) => securityEnabled = securityConfiguration.enabled
+    );
+
+    return {
+        'request': function (config) {
+            const headers = config.headers || {};
+            if (securityEnabled && config.url.includes('rest/') && !config.url.includes('rest/authentication/config')) {
+                return AuthenticationService.getAccessToken().then(token => {
+                    if (token) {
+                        headers['Authorization'] = `Bearer ${token}`;
+                    }
+                    config.headers = headers;
+                    return config;
+                });
+            }
+
+            config.headers = headers;
+            return config;
+        }
+    }
+}
+
+export default AuthenticationInterceptorModule;

--- a/src/interceptors/unauthorized.interceptor.js
+++ b/src/interceptors/unauthorized.interceptor.js
@@ -1,0 +1,20 @@
+const UnauthorizedInterceptorModule = angular.module('tt2ps.interceptors.unauthorized', []);
+UnauthorizedInterceptorModule.factory('UnauthorizedInterceptor', UnauthorizedInterceptor);
+
+UnauthorizedInterceptor.$inject = ['$q', '$location'];
+
+/**
+ * Intercepts $http responses and redirects to the login page if a 401 error occurs.
+ */
+function UnauthorizedInterceptor($q, $location) {
+    return {
+        'responseError': function(response) {
+            if (response.status === 401) {
+                $location.path('login');
+            }
+            return $q.reject(response);
+        }
+    };
+}
+
+export default UnauthorizedInterceptorModule;

--- a/src/layout.html
+++ b/src/layout.html
@@ -8,10 +8,6 @@
 </head>
     <body ng-controller="mainCtrl">
         <div class="page">
-            <div class="left-sidebar">
-                <img class="statnett-logo" src="images/statnett-logo-primary-green.svg" alt="Statnett company logo"/>
-                <chat-questions class="chat-questions"></chat-questions>
-            </div>
             <main class="view-content" role="main">
                 <header>
                     <tt2ps-header></tt2ps-header>

--- a/src/models/security/authentication-state.js
+++ b/src/models/security/authentication-state.js
@@ -1,0 +1,8 @@
+/**
+ * Authentication states for the user.
+ */
+export const AuthenticationState = {
+    NOT_AUTHENTICATED: 'NOT_AUTHENTICATED',
+    AUTHENTICATION_IN_PROGRESS: 'AUTHENTICATION_IN_PROGRESS',
+    AUTHENTICATED: 'AUTHENTICATED'
+};

--- a/src/models/security/security-configuration.js
+++ b/src/models/security/security-configuration.js
@@ -1,0 +1,55 @@
+/**
+ * Represents the security configuration settings for authentication.
+ */
+export class SecurityConfigurationModel {
+    /**
+     * Creates a new SecurityConfigurationModel instance.
+     *
+     * @param {Object} [data={}] - The configuration data.
+     * @param {boolean} [data.enabled=false] - Indicates if security is enabled.
+     * @param {string} [data.clientId] - The application (client) ID registered in Microsoft Entra ID.
+     * @param {string} [data.authority] - The authority URL (tenant-specific or common) used for authentication.
+     * @param {string} [data.logout] - The logout endpoint URL.
+     * @param {string} [data.loginRedirect] - The URL to redirect to after successful login.
+     * @param {string} [data.logoutRedirect] - The URL to redirect to after logout.
+     */
+    constructor(data = {}) {
+        /**
+         * Indicates if security is enabled.
+         * @type {boolean}
+         */
+        this.enabled = data.enabled !== undefined ? data.enabled : false;
+
+        /**
+         * The application (client) ID registered in Microsoft Entra ID.
+         * @type {string|undefined}
+         */
+        this.clientId = data.clientId;
+
+        /**
+         * The authority URL (tenant-specific or common) used for authentication.
+         * Example: "https://login.microsoftonline.com/{tenantId}"
+         * @type {string|undefined}
+         */
+        this.authority = data.authority;
+
+        /**
+         * The logout endpoint URL.
+         * @type {string|undefined}
+         */
+        this.logout = data.logout;
+
+        /**
+         * URL to redirect to after login.
+         * Must match the redirect URI registered in the Azure app.
+         * @type {string|undefined}
+         */
+        this.loginRedirect = data.loginRedirect;
+
+        /**
+         * URL to redirect to after logout.
+         * @type {string|undefined}
+         */
+        this.logoutRedirect = data.logoutRedirect;
+    }
+}

--- a/src/models/security/user.js
+++ b/src/models/security/user.js
@@ -1,0 +1,15 @@
+export class UserModel {
+    constructor(data = {}) {
+        /**
+         * The username of the user.
+         * @type {string}
+         */
+        this.username = data.username || '';
+
+        /**
+         * The full name of the user.
+         * @type {string}
+         */
+        this.name = data.name || '';
+    }
+}

--- a/src/models/tt2ps-event-name.js
+++ b/src/models/tt2ps-event-name.js
@@ -1,0 +1,20 @@
+/**
+ * Constants representing event names used in the TT2PS application.
+ * These events can be emitted and listened to for reacting to changes in security and authentication state.
+ */
+export const TT2PSEventName = {
+    /**
+     * Emitted when the security configuration has changed.
+     */
+    SECURITY_CONFIGURATION_CHANGED: 'securityConfigurationChanged',
+
+    /**
+     * Emitted when the authenticated user changes.
+     */
+    AUTHENTICATED_USER_CHANGED: 'authenticatedUserChanged',
+
+    /**
+     * Emitted when the authentication state changes (e.g., from not authenticated to authenticated).
+     */
+    AUTHENTICATION_STATE_CHANGED: 'authenticationStateChanged',
+};

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,5 +4,10 @@ export default [
         controller: 'chatCtrl',
         template: './views/chat/chat.html',
         lazyModule: './views/chat/chat.controller.js',
+    }, {
+        path: '/login',
+        controller: 'loginCtrl',
+        template: './views/login/login.html',
+        lazyModule: './views/login/login.controller.js',
     }
 ];

--- a/src/services/chat/chat.rest.service.fake.backend.js
+++ b/src/services/chat/chat.rest.service.fake.backend.js
@@ -1,6 +1,7 @@
 // Delay for askQuestion()
 const ASK_DELAY = 2;
 const EXPLAIN_DELAY = 2;
+const CONFIGURATION_DELAY = 2;
 
 export class ChatRestServiceFakeBackend {
 
@@ -182,5 +183,17 @@ export class ChatRestServiceFakeBackend {
         // return new Promise((resolve, reject) => setTimeout(() => reject({status: 400,}), ASK_DELAY));
         // return new Promise((resolve, reject) => setTimeout(() => reject({status: 422,}), ASK_DELAY));
         // return new Promise((resolve, reject) => setTimeout(() => reject({status: 425,}), ASK_DELAY));
+    }
+
+    getConfiguration() {
+        const securityConfig = {
+            enabled: true,
+            clientId: '<client_id>',
+            authority: 'https://login.microsoftonline.com/<tenant_id>',
+            logout: 'https://login.microsoftonline.com/<tenant_id>/oauth2/logout',
+            loginRedirect: 'http://localhost:3000',
+            logoutRedirect: 'http://localhost:3000/login'
+        };
+        return new Promise((resolve) => setTimeout(() => resolve({data: securityConfig}), CONFIGURATION_DELAY));
     }
 }

--- a/src/services/chat/chat.rest.service.js
+++ b/src/services/chat/chat.rest.service.js
@@ -1,4 +1,5 @@
 import {ChatRestServiceFakeBackend} from './chat.rest.service.fake.backend';
+import {DEVELOPMENT} from "../../configurations/app-configurations";
 
 const ChatRestServiceModule = angular
     .module('tt2ps.services.chat.chat-rest-service', []);
@@ -10,8 +11,6 @@ ChatRestService.$inject = ['$http'];
 const CONVERSATIONS_ENDPOINT = 'rest/chat/conversations';
 const EXPLAIN_RESPONSE_ENDPOINT = `${CONVERSATIONS_ENDPOINT}/explain`;
 const LOAD_QUESTIONS_ENDPOINT = 'assets/data/questions.json';
-
-const DEVELOPMENT = false;
 
 function ChatRestService($http) {
 

--- a/src/services/security/authentication.service.js
+++ b/src/services/security/authentication.service.js
@@ -1,0 +1,225 @@
+/**
+ * AngularJS module providing authentication services.
+ */
+
+import {PublicClientApplication, InteractionRequiredAuthError} from '@azure/msal-browser';
+import angular from 'angular';
+import SecurityContextServiceModule from './security-context.service';
+import {AuthenticationState} from "../../models/security/authentication-state";
+
+const dependencies = [
+    SecurityContextServiceModule.name
+];
+
+const AuthenticationModule = angular.module('tt2ps.services.authentication-service', dependencies);
+AuthenticationModule.factory('AuthenticationService', AuthenticationService);
+
+AuthenticationService.$inject = ['$q', '$rootScope', '$location', '$window', 'SecurityContextService'];
+
+/**
+ * AuthenticationService handles login, logout, access token acquisition, and tracks authentication state..
+ */
+function AuthenticationService($q, $rootScope, $location, $window, SecurityContextService) {
+    const OIDC_SCOPES = ['openid', 'profile'];
+    let msalInstance = null;
+    let _securityConfiguration = null;
+
+    /**
+     * Wraps an async function in a $q promise and ensures $rootScope digest.
+     *
+     * @param {Function} fn - The async function to wrap.
+     * @returns {Promise<any>} A promise resolving or rejecting with the async result.
+     */
+    const wrapAsync = (fn) => {
+        return $q((resolve, reject) => {
+            Promise.resolve(fn())
+                .then(resolve)
+                .catch(reject)
+                .finally(() => $rootScope.$applyAsync());
+        });
+    };
+
+    /**
+     * Initializes the MSAL instance with the given security configuration.
+     *
+     * @param {SecurityConfigurationModel} securityConfiguration - Configuration object with clientId, authority, loginRedirect, etc.
+     * @returns {angular.Promise<PublicClientApplication>} Promise resolving with the MSAL instance.
+     */
+    const initialize = (securityConfiguration) => {
+        _securityConfiguration = securityConfiguration;
+        return wrapAsync(async () => {
+            if (msalInstance) return msalInstance;
+
+            const config = {
+                auth: {
+                    clientId: _securityConfiguration.clientId,
+                    authority: _securityConfiguration.authority,
+                    redirectUri: _securityConfiguration.loginRedirect,
+                    postLogoutRedirectUri: _securityConfiguration.logoutRedirect
+                },
+                cache: {
+                    cacheLocation: 'localStorage',
+                    storeAuthStateInCookie: false,
+                },
+                system: {
+                    loggerOptions: {
+                        loggerCallback: (level, message) => {
+                            if (level <= 2) console.log('[MSAL]', message);
+                        },
+                        piiLoggingEnabled: false,
+                    },
+                },
+            };
+
+            msalInstance = await PublicClientApplication.createPublicClientApplication(config);
+
+            // Handle redirect login response
+            await wrapAsync(async () => {
+                const response = await msalInstance.handleRedirectPromise();
+                await loginResponseHandler(response);
+            });
+
+            return msalInstance;
+        });
+    };
+
+    /**
+     * Gets the currently active account.
+     *
+     * @returns {angular.Promise<Object|null>} Promise resolving with the active account or null.
+     */
+    const getActiveAccount = () => wrapAsync(() => msalInstance?.getActiveAccount() || null);
+
+    /**
+     * Checks if the user is authenticated.
+     *
+     * @returns {angular.Promise<boolean>} Promise resolving with true if authenticated, false otherwise.
+     */
+    const isAuthenticated = () => getActiveAccount().then(account => !!account);
+
+    /**
+     * Logs in the user.
+     * Updates the SecurityContextService authentication state and shows toast errors if login fails.
+     *
+     * @returns {angular.Promise<Object>} Promise resolving with the authenticated account.
+     * @throws Will throw an error if login fails.
+     */
+    const login = () =>
+        wrapAsync(async () => {
+            SecurityContextService.updateAuthenticationState(AuthenticationState.AUTHENTICATION_IN_PROGRESS);
+            cleanStorage();
+            await msalInstance.loginRedirect({
+                scopes: [...OIDC_SCOPES],
+                redirectStartPage: _securityConfiguration.loginRedirect
+            });
+            return msalInstance.getActiveAccount();
+        });
+
+    /**
+     * Logs out the currently active user.
+     *
+     * @returns {angular.Promise<void>} Promise resolving when logout completes.
+     */
+    const logout = () =>
+        wrapAsync(async () => {
+            const account = msalInstance.getActiveAccount();
+            if (account) {
+                await msalInstance.logoutRedirect({
+                    account,
+                    postLogoutRedirectUri: _securityConfiguration.loginRedirect
+                });
+            }
+            SecurityContextService.updateAuthenticationState(AuthenticationState.NOT_AUTHENTICATED);
+            msalInstance = null;
+            cleanStorage();
+        });
+
+    /**
+     * Acquires an access token.
+     *
+     * @returns {angular.Promise<string>} Promise resolving with the access token.
+     * @throws Will throw an error if no active account is available or token acquisition fails.
+     */
+    const getAccessToken = () =>
+        wrapAsync(async () => {
+            const account = msalInstance.getActiveAccount();
+            if (!account) throw new Error('No active account');
+
+            const request = {account};
+            try {
+                const res = await msalInstance.acquireTokenSilent(request);
+                return res.accessToken;
+            } catch (err) {
+                if (err instanceof InteractionRequiredAuthError) {
+                    const res = await msalInstance.acquireTokenPopup(request);
+                    return res.accessToken;
+                }
+                throw err;
+            }
+        });
+
+    /**
+     * Handles the response returned by MSAL redirect login.
+     *
+     * @param {Object} response - The response from handleRedirectPromise()
+     * @returns {Promise<void>}
+     */
+    const loginResponseHandler = async (response) => {
+        cleanStorage();
+
+        if (response?.account) {
+            msalInstance.setActiveAccount(response.account);
+            SecurityContextService.updateAuthenticationState(AuthenticationState.AUTHENTICATED);
+        } else if (await isAuthenticated()) {
+            SecurityContextService.updateAuthenticationState(AuthenticationState.AUTHENTICATED);
+        } else {
+            SecurityContextService.updateAuthenticationState(AuthenticationState.NOT_AUTHENTICATED);
+        }
+
+        clearRedirectUrl();
+    };
+
+    /**
+     * Cleans up session storage. This is important to:
+     * - Prevents MSAL from thinking a login is still in progress;
+     * - Avoids errors if the user logs in multiple times in the same session.
+     */
+    const cleanStorage = () => {
+        const itemKey = "msal.interaction.status";
+        if (sessionStorage.getItem(itemKey)) {
+            sessionStorage.removeItem(itemKey);
+        }
+    };
+
+    /**
+     * Clears temporary query parameters and hash added by MSAL after redirect login.
+     * Updates the browser URL to either the configured redirect URL or the current path,
+     * without reloading the page.
+     */
+    const clearRedirectUrl = () => {
+        let redirectUrl = _securityConfiguration?.loginRedirect;
+
+        if (!redirectUrl) {
+            // Remove query parameters and hash
+            $location.search({});
+            $location.hash('');
+            redirectUrl = $window.location.origin + $location.path();
+        } else {
+            $location.url(redirectUrl);
+        }
+
+        // Update the browser URL without reloading the page
+        $window.history.replaceState({}, document.title, redirectUrl);
+    };
+
+    return {
+        initialize,
+        isAuthenticated,
+        getActiveAccount,
+        login,
+        logout,
+        getAccessToken
+    };
+}
+
+export default AuthenticationModule;

--- a/src/services/security/mappers/security-configuration-mapper.js
+++ b/src/services/security/mappers/security-configuration-mapper.js
@@ -1,0 +1,20 @@
+import {SecurityConfigurationModel} from "../../../models/security/security-configuration";
+
+/**
+ * Converts the response from the server to a SecurityConfigurationModel instance.
+ * @param {*} data
+ * @return {SecurityConfigurationModel|undefined}
+ */
+export const securityConfigModelMapper = (data) => {
+    if (!data) {
+        return;
+    }
+    return new SecurityConfigurationModel({
+        enabled: data.enabled,
+        clientId: data.clientId,
+        authority: data.authority,
+        logout: data.logout,
+        loginRedirect: data.loginRedirect,
+        logoutRedirect: data.logoutRedirect
+    });
+};

--- a/src/services/security/security-context.service.js
+++ b/src/services/security/security-context.service.js
@@ -1,0 +1,161 @@
+import {cloneDeep} from 'lodash';
+import {TT2PSEventName} from "../../models/tt2ps-event-name";
+import {AuthenticationState} from "../../models/security/authentication-state";
+const SecurityContextServiceModule = angular.module('tt2ps.services.security-context-service', []);
+SecurityContextServiceModule.factory('SecurityContextService', SecurityContextService);
+
+SecurityContextService.$inject = ['EventEmitterService'];
+
+
+function SecurityContextService(EventEmitterService) {
+
+    /**
+     * @type {SecurityConfigurationModel|undefined}
+     */
+    let _securityConfiguration = undefined;
+
+    /**
+     *
+     * @type {UserModel}
+     */
+    let _authenticatedUser = undefined;
+
+    /**
+     * Return the security configuration.
+     * @return {SecurityConfigurationModel|undefined}
+     */
+    const getSecurityConfiguration = () => {
+        return cloneDeep(_securityConfiguration);
+    }
+
+    /**
+     * Updates the security configuration and emits the 'securityConfigurationChanged' event to notify listeners that
+     * the security configuration has changed.
+     *
+     * @param {SecurityConfigurationModel|undefined} securityConfiguration - The security configuration that is being updated.
+     */
+    const updateSecurityConfiguration = (securityConfiguration) => {
+        _securityConfiguration = cloneDeep(securityConfiguration);
+        emit(TT2PSEventName.SECURITY_CONFIGURATION_CHANGED, getSecurityConfiguration());
+    };
+
+    /**
+     * Subscribes to the 'securityConfigurationChanged' event.
+     * @param {function} callback - The callback to be called when the event is fired.
+     *
+     * @return {function} unsubscribe function.
+     */
+    const onSecurityConfigurationChanged = (callback) => {
+        if (_securityConfiguration && angular.isFunction(callback)) {
+            callback(getSecurityConfiguration());
+        }
+        return subscribe(TT2PSEventName.SECURITY_CONFIGURATION_CHANGED, (chats) => callback(chats));
+    }
+
+    /**
+     * Return the authenticated user of undefined.
+     * @return {UserModel|undefined}
+     */
+    const getAuthenticatedUser = () => {
+        return cloneDeep(_authenticatedUser);
+    }
+
+    /**
+     * Updates the authenticated user and emits the 'authenticatedUserChanged' event to notify listeners that
+     * the authenticated user has changed.
+     *
+     * @param {UserModel|undefined} user - The authenticated user that is being updated.
+     */
+    const updateAuthenticatedUser = (user) => {
+        _authenticatedUser = cloneDeep(user);
+        emit(TT2PSEventName.AUTHENTICATED_USER_CHANGED, getAuthenticatedUser());
+    };
+
+    /**
+     * Subscribes to the 'authenticatedUserChanged' event.
+     * @param {function} callback - The callback to be called when the event is fired.
+     *
+     * @return {function} unsubscribe function.
+     */
+    const onAuthenticatedUserChanged = (callback) => {
+        if (_authenticatedUser && angular.isFunction(callback)) {
+            callback(getAuthenticatedUser());
+        }
+        return subscribe(TT2PSEventName.AUTHENTICATED_USER_CHANGED, (chats) => callback(chats));
+    }
+
+    /**
+     * @type {'NOT_AUTHENTICATED' | 'AUTHENTICATION_IN_PROGRESS' | 'AUTHENTICATED'}
+     * @private
+     */
+    let _authenticationState = AuthenticationState.NOT_AUTHENTICATED;
+
+    /**
+     * Returns the current authentication state.
+     * @return {'NOT_AUTHENTICATED' | 'AUTHENTICATION_IN_PROGRESS' | 'AUTHENTICATED'}
+     */
+    const getAuthenticationState = () => {
+        return _authenticationState;
+    };
+
+    /**
+     * Updates the authentication state and emits the 'authenticationStateChanged' event to notify listeners that
+     * the authentication state has changed.
+     *
+     * @param {'NOT_AUTHENTICATED' | 'AUTHENTICATION_IN_PROGRESS' | 'AUTHENTICATED'} authenticationState - The authentication state that is being updated.
+     */
+    const updateAuthenticationState = (authenticationState) => {
+        _authenticationState = authenticationState;
+        emit(TT2PSEventName.AUTHENTICATION_STATE_CHANGED, getAuthenticationState());
+    };
+
+    /**
+     * Subscribes to the 'authenticationStateChanged' event.
+     * @param {function} callback - The callback to be called when the event is fired.
+     *
+     * @return {function} unsubscribe function.
+     */
+    const onAuthenticationStateChanged = (callback) => {
+        if (angular.isFunction(callback)) {
+            callback(getAuthenticationState());
+        }
+        return subscribe(TT2PSEventName.AUTHENTICATION_STATE_CHANGED, (authenticationState) => callback(authenticationState));
+    }
+
+    /**
+     * Emits an event with a deep-cloned payload using the EventEmitterService.
+     *
+     * @param {string} tT2PSEventName - The name of the event to emit. It must be a value from {@link TT2PSEventName}.
+     * @param {*} payload - The data to emit with the event. The payload is deep-cloned before emission.
+     */
+    const emit = (tT2PSEventName, payload) => {
+        EventEmitterService.emitSync(tT2PSEventName, cloneDeep(payload));
+    };
+
+    /**
+     * Subscribes to an event with the specified callback using the EventEmitterService.
+     *
+     * @param {string} tT2PSEventName - The name of the event to subscribe to. It must be a value from {@link TT2PSEventName}.
+     * @param {function} callback - The function to call when the event is emitted.
+     * @return {function} - Returns a function that can be called to unsubscribe from the event.
+     */
+    const subscribe = (tT2PSEventName, callback) => {
+        return EventEmitterService.subscribeSync(tT2PSEventName, (payload) => callback(payload));
+    };
+
+    return {
+        emit,
+        subscribe,
+        getSecurityConfiguration,
+        updateSecurityConfiguration,
+        onSecurityConfigurationChanged,
+        getAuthenticatedUser,
+        updateAuthenticatedUser,
+        onAuthenticatedUserChanged,
+        getAuthenticationState,
+        updateAuthenticationState,
+        onAuthenticationStateChanged
+    }
+}
+
+export default SecurityContextServiceModule;

--- a/src/services/security/security.rest.service.js
+++ b/src/services/security/security.rest.service.js
@@ -1,0 +1,35 @@
+import {DEVELOPMENT} from "../../configurations/app-configurations";
+import {ChatRestServiceFakeBackend} from "../chat/chat.rest.service.fake.backend";
+
+const SecurityRestServiceModule = angular.module('tt2ps.services.security-rest-service', []);
+SecurityRestServiceModule.factory('SecurityRestService', SecurityRestService);
+
+SecurityRestService.$inject = ['$http'];
+
+const SECURITY_CONFIGURATION_ENDPOINT = 'rest/authentication/config';
+
+const _fakeBackend = new ChatRestServiceFakeBackend();
+
+function SecurityRestService($http) {
+
+    /**
+     * Fetches the security configuration from the backend.
+     *
+     * @returns {Promise<Object>} Promise resolving to the security configuration object.
+     */
+    const getConfiguration = () => {
+        if (DEVELOPMENT) {
+            return $http.get(SECURITY_CONFIGURATION_ENDPOINT)
+                .catch(() => {
+                    return _fakeBackend.getConfiguration();
+                });
+        }
+        return $http.get(SECURITY_CONFIGURATION_ENDPOINT);
+    };
+
+    return {
+        getConfiguration
+    }
+}
+
+export default SecurityRestServiceModule;

--- a/src/services/security/security.service.js
+++ b/src/services/security/security.service.js
@@ -1,0 +1,36 @@
+import { securityConfigModelMapper } from "./mappers/security-configuration-mapper";
+import SecurityRestServiceModule from "./security.rest.service";
+
+const dependencies = [
+    SecurityRestServiceModule.name
+];
+
+const SecurityServiceModule = angular.module('tt2ps.services.security-service', dependencies);
+SecurityServiceModule.factory('SecurityService', SecurityService);
+
+SecurityService.$inject = ['SecurityRestService'];
+
+/**
+ * SecurityService providing security-related services.
+ */
+function SecurityService(SecurityRestService) {
+
+    /**
+     * Retrieves the security configuration from the backend and maps it to the client model.
+     *
+     * @function
+     * @returns {Promise<Object>} A promise that resolves to the mapped security configuration.
+     */
+    const getConfiguration = () => {
+        return SecurityRestService.getConfiguration()
+            .then((response) => {
+                return securityConfigModelMapper(response.data);
+            });
+    };
+
+    return {
+        getConfiguration
+    };
+}
+
+export default SecurityServiceModule;

--- a/src/services/toast.service.js
+++ b/src/services/toast.service.js
@@ -1,0 +1,50 @@
+import 'angular-toastr';
+import angular from "angular";
+
+const ToastrServiceModule = angular.module("tt2ps.services.toastr-service", [
+    'toastr'
+]);
+
+/**
+ * Configure the angular-toastr global settings for the application.
+ */
+ToastrServiceModule.config(['toastrConfig', function(toastrConfig) {
+    angular.extend(toastrConfig, {
+        timeOut: 5000,
+        positionClass: 'toast-bottom-right',
+        tapToDismiss: false,
+        allowHtml: true,
+        extendedTimeOut: 5000
+    });
+}]);
+
+ToastrServiceModule.factory("ToastrService", ToastrService);
+ToastrService.$inject = ['toastr'];
+
+/**
+ * Service providing wrapper methods around angular-toastr for displaying notifications.
+ */
+function ToastrService(toastr) {
+    const decodeHtmlEntities = (text) => {
+        const txt = document.createElement("textarea");
+        txt.innerHTML = text;
+        return txt.value;
+    };
+
+    const show = (type, message, title) => {
+        toastr[type](decodeHtmlEntities(message), title || undefined, {
+            allowHtml: true,
+            closeButton: true,
+            timeOut: 5000,
+        });
+    };
+
+    return {
+        success: (message, title) => show("success", message, title),
+        error: (message, title) => show("error", message, title),
+        info: (message, title) => show("info", message, title),
+        warning: (message, title) => show("warning", message, title),
+    };
+}
+
+export default ToastrServiceModule;

--- a/src/styles/scss/partials/_buttons.scss
+++ b/src/styles/scss/partials/_buttons.scss
@@ -20,6 +20,7 @@
   padding: .5rem 1rem;
   font-size: 1rem;
   border-radius: 0;
+  text-decoration: none;
 
   &:hover [class^="icon-"],
   &:hover .fa,

--- a/src/styles/scss/partials/_general.scss
+++ b/src/styles/scss/partials/_general.scss
@@ -22,27 +22,8 @@ body {
     */
     min-height: 0;
 
-    .left-sidebar {
-      flex: 0 0 20%;
-      max-width: 20rem;
-      padding-top: 1rem;
-      display: flex;
-      flex-direction: column;
-      gap: 2rem;
-
-      .statnett-logo {
-        max-height: 2rem;
-      }
-
-      .chat-questions {
-        flex: 1;
-        overflow-y: auto;
-        background-color: var(--base-background-color);
-      }
-    }
-
     header {
-      padding: 1rem;
+      padding-bottom: 1rem;
     }
 
     .view-content {

--- a/src/styles/scss/partials/_variables.scss
+++ b/src/styles/scss/partials/_variables.scss
@@ -49,6 +49,8 @@
     --base-background-color: #f7f7f7;
     /* The base background color that is used for selected panels or elements */
     --base-background-selected-color: #dcdcdc;
+    --base-dropdown-color: #ebebeb;
+    --base-dropdown-hovered-color: #d4d4d4;
 
     --statenate-red-color: #e30613;
     --statenett-green-color: #05ce74;

--- a/src/views/chat/chat.controller.js
+++ b/src/views/chat/chat.controller.js
@@ -14,20 +14,19 @@ const modules = [
     ChatServiceModule.name
 ];
 
-const ChatModule = angular
-    .module('tt2ps.chat.controllers.chat-ctrl', modules);
+const ChatModule = angular.module('tt2ps.controllers.chat-ctrl', modules);
 ChatModule
     .controller('chatCtrl', ChatCtrl)
 
 ChatCtrl.$inject = [
     '$scope',
     '$translate',
-    'toastr',
+    'ToastrService',
     'ChatService',
     'ChatContextService'
 ]
 
-function ChatCtrl($scope, $translate, toastr, ChatService, ChatContextService) {
+function ChatCtrl($scope, $translate, ToastrService, ChatService, ChatContextService) {
     const init = () => {
         loadChatQuestionList();
         ChatContextService.selectChat(new ChatModel());
@@ -61,9 +60,9 @@ function ChatCtrl($scope, $translate, toastr, ChatService, ChatContextService) {
                 if (status === 400) {
                     ChatContextService.emit(ChatContextEventName.CONVERSATION_EXPIRED);
                 } else if (status === 422) {
-                    toastr.error($translate.instant('chat_panel.error.unprocessable_entity'));
+                    ToastrService.error($translate.instant('chat_panel.error.unprocessable_entity'));
                 } else {
-                    toastr.error($translate.instant('chat_panel.error.create_chat_failure'));
+                    ToastrService.error($translate.instant('chat_panel.error.create_chat_failure'));
                 }
             });
     };
@@ -81,15 +80,15 @@ function ChatCtrl($scope, $translate, toastr, ChatService, ChatContextService) {
                 if (status === 400) {
                     ChatContextService.emit(ChatContextEventName.CONVERSATION_EXPIRED);
                 } else if (status === 422) {
-                    toastr.error($translate.instant('chat_panel.error.unprocessable_entity'));
+                    ToastrService.error($translate.instant('chat_panel.error.unprocessable_entity'));
                 } else {
-                    toastr.error($translate.instant('chat_panel.error.ask_question_failure'));
+                    ToastrService.error($translate.instant('chat_panel.error.ask_question_failure'));
                 }
             });
     }
 
     const onConversationExpired = (chatQuestion) => {
-        toastr.error($translate.instant('chat_panel.error.conversation_not_found'));
+        ToastrService.error($translate.instant('chat_panel.error.conversation_not_found'));
         ChatContextService.selectChat(new ChatModel());
     }
 

--- a/src/views/chat/chat.html
+++ b/src/views/chat/chat.html
@@ -1,3 +1,4 @@
 <div class="chat-view">
+    <chat-questions class="chat-questions"></chat-questions>
     <chat-panel></chat-panel>
 </div>

--- a/src/views/chat/chat.scss
+++ b/src/views/chat/chat.scss
@@ -1,7 +1,15 @@
 .chat-view {
   height: 100%;
   width: 100%;
+  display: flex;
+
+  .chat-questions {
+    flex: 0 0 20.5%;
+  }
+
   chat-panel {
+    flex: 1;
     height: 100%;
+    overflow-x: auto;
   }
 }

--- a/src/views/login/login.controller.js
+++ b/src/views/login/login.controller.js
@@ -1,0 +1,75 @@
+import './login.scss';
+import AuthenticationModule from "../../services/security/authentication.service";
+import LoginButton from "../../directives/core/login-button/login-button";
+import SecurityContextServiceModule from "../../services/security/security-context.service";
+import {AuthenticationState} from "../../models/security/authentication-state";
+
+const dependencies = [
+    AuthenticationModule.name,
+    LoginButton.name,
+    SecurityContextServiceModule.name
+];
+const LoginModule = angular.module('tt2ps.controllers.login-ctrl', dependencies);
+
+LoginModule.controller('loginCtrl', LoginCtrl);
+
+LoginCtrl.$inject = [
+    '$scope',
+    'AuthenticationService',
+    'SecurityContextService'
+];
+
+/**
+ * Controller for the login view.
+ */
+function LoginCtrl($scope, AuthenticationService, SecurityContextService) {
+
+    // =========================
+    // Public variables
+    // =========================
+
+    /**
+     * Current authentication state.
+     * Can be one of `AuthenticationState.NOT_AUTHENTICATED`, `AuthenticationState.AUTHENTICATION_IN_PROGRESS`, or `AuthenticationState.AUTHENTICATED`.
+     * @type {string}
+     */
+    $scope.authenticationState = AuthenticationState.NOT_AUTHENTICATED;
+
+    /**
+     * Flag indicating whether security is enabled.
+     * @type {boolean}
+     */
+    $scope.isSecurityEnabled = false;
+
+    // =========================
+    // Private variables
+    // =========================
+
+    /**
+     * Array of subscription functions to unsubscribe from when the header is destroyed.
+     * @type {*[]}
+     */
+    const subscriptions = [];
+
+
+    // =========================
+    // Private functions
+    // =========================
+    const onAuthenticationStateChanged = (authenticationState) => {
+        $scope.authenticationState = authenticationState;
+    };
+
+    const onSecurityConfigurationChanged = (securityConfiguration) => {
+        $scope.isSecurityEnabled = securityConfiguration.enabled;
+    };
+
+    // =========================
+    // Subscriptions
+    // =========================
+    subscriptions.push(SecurityContextService.onAuthenticationStateChanged(onAuthenticationStateChanged));
+    subscriptions.push(SecurityContextService.onSecurityConfigurationChanged(onSecurityConfigurationChanged));
+
+    $scope.$on('$destroy', () => subscriptions.forEach((subscription) => subscription()))
+}
+
+export default LoginModule;

--- a/src/views/login/login.html
+++ b/src/views/login/login.html
@@ -1,0 +1,32 @@
+<div class="login-container">
+    <div ng-if="isSecurityEnabled">
+        <div class="login-content" ng-if="authenticationState === 'AUTHENTICATED'">
+            <div class="title">{{ 'tt2ps.login.already_logged_in' | translate }}</div>
+            <p>{{ 'tt2ps.login.you_are_already_logged_in' | translate }}</p>
+            <div class="login-actions">
+                <a class="btn btn-primary" href="/">{{ 'tt2ps.login.go_to_chatbot' | translate }}</a>
+            </div>
+        </div>
+
+        <div class="login-content" ng-if="authenticationState === 'AUTHENTICATION_IN_PROGRESS'">
+            <div tt2ps-loader size="40"></div>
+        </div>
+
+        <div class="login-content" ng-if="authenticationState === 'NOT_AUTHENTICATED'">
+            <div class="title">{{ 'tt2ps.login.not_logged_in' | translate }}</div>
+            <p>{{ 'tt2ps.login.login_required' | translate }}</p>
+            <div class="login-actions">
+                <login-button></login-button>
+            </div>
+        </div>
+    </div>
+    <div ng-if="!isSecurityEnabled">
+        <div class="login-content">
+            <div class="title">{{ 'tt2ps.login.security_not_enabled' | translate }}</div>
+            <p>{{ 'tt2ps.login.security_not_enabled_description' | translate }}</p>
+            <div class="login-actions">
+                <a class="btn btn-primary" href="/">{{ 'tt2ps.login.go_to_chatbot' | translate }}</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/views/login/login.scss
+++ b/src/views/login/login.scss
@@ -1,0 +1,23 @@
+.login-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 50vh;
+  padding: 20px;
+  text-align: center;
+
+  .login-content {
+    max-width: 500px;
+    width: 100%;
+
+    .title {
+      font-size: 2rem;
+    }
+  }
+
+  .login-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 20px;
+  }
+}


### PR DESCRIPTION
## What
Added management of user sessions in the Chatbot UI.

## Why
To make the Chatbot application secure and control who can access it.

## How
- @azure/msal-browser is used for login, logout, and token management, including refreshing tokens when they expire;
- Added a login page;
- Added an interceptor that redirects to the login page when the backend returns a 401 error;
- Added an interceptor that adds the authorization token to the Authorization header for backend requests. The getAccessToken method of AuthenticationService handles returning the token and automatically refreshes it if expired;
- Added a logout button.