### PR TITLE
Updates couple of deployment resources in order to fix proxying issues

### DIFF
--- a/helm-charts/files/chatbot-services-proxy.conf
+++ b/helm-charts/files/chatbot-services-proxy.conf
@@ -1,22 +1,27 @@
+# This is a configuration snippet added into specific directory containing configuration includes.
+# There includes will be added to the default web application '.conf' file.
+
+# The configuration snipped defines proxy routes for the backend service, which will intercept the web application
+# requests and reroute them to the correct backend service address.
+# Additionally, it fixes the routing to GraphDB, because it is invoked with the context path of the web application,
+# which should be stripped. 
+
+
 {{- $backend := required "The backend URL is required!" .Values.configuration.backend.url -}}
 {{- $backendUrl := urlParse $backend -}}
 {{- $chatContextPath := trimSuffix "/" .Values.configuration.contextPath -}}
 {{- $backendLocPath := printf "%s/rest/" $chatContextPath -}}
 {{- $graphdbLocPath := printf "%s/graphdb/" $chatContextPath -}}
-server {
-  listen 8080;
-  server_name localhost {{ $backendUrl.hostname }};
 
-  # Proxies the request for the Chatbot service to the correct address.
-  location ~ ^{{ printf "%s" $backendLocPath }}(.*)$ {
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    set $upstream {{ printf "%s/rest/" ($backend | trimSuffix "/") }};
-    proxy_pass $upstream$1;
-  }
+# Proxies the request for the Chatbot service to the correct address.
+location ~ ^{{ printf "%s" $backendLocPath }}(.*)$ {
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  set $upstream {{ printf "%s" ($backend | trimSuffix "/") }};
+  proxy_pass $upstream/rest/$1;
+}
 
-  # Strips the '/chat' context path when redirecting to GraphDB
-  location ^~ {{ printf "%s" $graphdbLocPath }} {
-    rewrite ^{{ printf "%s" $graphdbLocPath }}(.*)$ /graphdb/$1 permanent;
-  }
+# Strips the '/chat' context path when redirecting to GraphDB
+location ^~ {{ printf "%s" $graphdbLocPath }} {
+  rewrite ^{{ printf "%s" $graphdbLocPath }}(.*)$ /graphdb/$1 permanent;
 }

--- a/helm-charts/templates/deployment.yaml
+++ b/helm-charts/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: {{ include "t2ps-chatbot.services.proxy.configuration" . }}
-              mountPath: /etc/nginx/conf.d/chatbot-services-proxy.conf
+              mountPath: /etc/nginx/includes/backend-proxy/chatbot-services-proxy.conf
               subPath: chatbot-services-proxy.conf
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/nginx/conf.d/chatbot-ui.conf
+++ b/nginx/conf.d/chatbot-ui.conf
@@ -15,4 +15,14 @@ server {
     add_header 'Content-Type' 'application/json';
     return 200 '{"status": "Healthy"}';
   }
+
+  # At the moment, the web application relies on relative paths to invoke the backend service API.
+  # However, the backend might not be present on the same environment, nor port as it is a external service.
+  # To make the application more flexible, we are going to optionally include additional configurations/snippets that
+  # will be added to the current config. These configurations can be used to proxy the requests that come out of the
+  # web application and route them to the correct address of the backend service.
+  #
+  # Note that the additional configurations should be placed in specific sub-directory and start with specific prefix!
+  # If there are no files, nothing will be included to the current configuration definition.
+  include /etc/nginx/includes/backend-proxy/chatbot-*.conf;
 }


### PR DESCRIPTION
- Updated the default Nginx configuration for the web application. We've added optional includes of configuration snippet files, which can be used to define specific proxying/routing to the correct address of the backend service API.

  This is needed, because currently the web application works with
relative paths in order to invoke the backend service. However, when the applications are deployed for example in Kubernetes, the backend service is external for the web application container.

- Updated the `chatbot-service-proxy.conf` to contain only a snippet that can be added to the default web application Nginx configuration. Also, now the files is mounted in specific directory for includes.