### PR TITLE
Sn 277 fix visgraph click handlers

### DIFF
--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -3,7 +3,7 @@ name: t2ps-chatbot-ui
 description: Web application for the Talk to the Power System Chatbot, served via Nginx Web Server
 type: application
 version: 1.0.3
-appVersion: "v2.0.0-rc4"
+appVersion: "v2.0.0-rc5"
 home: https://github.com/statnett/Talk2PowerSystem_UI
 sources:
   - https://github.com/statnett/Talk2PowerSystem_UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-2-power-system-ui",
-  "version": "2.0.0-rc4",
+  "version": "2.0.0-rc5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-2-power-system-ui",
-      "version": "2.0.0-rc4",
+      "version": "2.0.0-rc5",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/msal-browser": "^4.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk-2-power-system-ui",
-  "version": "2.0.0-rc4",
+  "version": "2.0.0-rc5",
   "description": "The web application for Talk 2 Power System APIs",
   "scripts": {
     "start": "webpack serve --mode development --env baseHref=/",

--- a/src/configurations/project-info.js
+++ b/src/configurations/project-info.js
@@ -1,7 +1,7 @@
 module.exports = {
   "project": {
     "name": "talk-2-power-system-ui",
-    "version": "2.0.0-rc4"
+    "version": "2.0.0-rc5"
   },
   "framework": {
     "name": "AngularJS",

--- a/src/directives/chat/chat-panel/chat-panel.directive.js
+++ b/src/directives/chat/chat-panel/chat-panel.directive.js
@@ -124,7 +124,7 @@ function ChatPanelDirective($translate, ChatContextService, QuestionsContextServ
              */
             const onAskForDiagramElement = (diagramElement) => {
                 if (diagramElement && !$scope.waitingForLastMessage ) {
-                    $scope.chatItem.question.message = `CLICKED_ON ${diagramElement.elementIRI}`;
+                    $scope.chatItem.question.message = `CLICKED_ON ${diagramElement.value}`;
                     $scope.chatItem.type = ChatItemType.DESCRIBE_DIAGRAM_ELEMENT;
                     $scope.ask();
                 }

--- a/src/directives/chat/diagrams-sidebar/diagrams-sidebar.directive.html
+++ b/src/directives/chat/diagrams-sidebar/diagrams-sidebar.directive.html
@@ -32,6 +32,13 @@
                 fullscreen="fullscreen">
         </svg-diagram>
 
+        <viz-graph-diagram
+                ng-switch-when="vizGraph"
+                ng-repeat="d in [selectedDiagram] track by d.hash"
+                diagram="d"
+                fullscreen="fullscreen">
+        </viz-graph-diagram>
+
         <image-diagram
                 ng-switch-when="image"
                 ng-repeat="d in [selectedDiagram] track by d.hash"

--- a/src/directives/chat/diagrams-sidebar/diagrams-sidebar.directive.js
+++ b/src/directives/chat/diagrams-sidebar/diagrams-sidebar.directive.js
@@ -82,14 +82,21 @@ function DiagramsSidebarDirective(ChatContextService) {
        * Exits fullscreen and removes the wheel-prevention handler.
        */
       $scope.exitFullscreen = () => {
-        $scope.fullscreen = false;
-        removeMouseWheelHandler();
-
         if (document.fullscreenElement) {
           document.exitFullscreen();
         }
       };
 
+      const handleFullscreenChange = () => {
+        const isFullscreen = !!document.fullscreenElement;
+        $scope.$applyAsync(() => {
+          $scope.fullscreen = isFullscreen;
+
+          if (!isFullscreen) {
+            removeMouseWheelHandler();
+          }
+        });
+      }
 
       //////////////////////////////
       // Private functions
@@ -138,12 +145,14 @@ function DiagramsSidebarDirective(ChatContextService) {
       subscriptions.push(ChatContextService.onSelectedDiagramChanged(onSelectedDiagramChanged));
 
       subscriptions.push(ChatContextService.subscribe(ChatContextEventName.SHOW_SELECTED_DIAGRAM_ON_FULLSCREEN, onShowSelectedDiagramOnFullscreen));
+      document.addEventListener('fullscreenchange', handleFullscreenChange);
 
       /**
        * Cleans up all listeners/subscriptions when directive is destroyed.
        */
       const removeAllSubscribers = () => {
         subscriptions.forEach((fn) => fn());
+        document.removeEventListener('fullscreenchange', handleFullscreenChange);
         removeMouseWheelHandler();
       };
 

--- a/src/directives/chat/diagrams-sidebar/diagrams-sidebar.directive.js
+++ b/src/directives/chat/diagrams-sidebar/diagrams-sidebar.directive.js
@@ -5,12 +5,14 @@ import DiagramServiceModule from '../../../services/diagrams/diagram.service';
 import ImageDiagramModule from './image-diagram/image-diagram.directive';
 import SvgDiagramModule from './svg-diagram/svg-diagram.directive';
 import IframeDiagramModule from './iframe-diagram/iframe-diagram.directive';
+import VizGraphDiagramModel from "./viz-graph-diagram/viz-graph-diagram.directive";
 
 const dependencies = [
   DiagramServiceModule.name,
   ImageDiagramModule.name,
   SvgDiagramModule.name,
-  IframeDiagramModule.name
+  IframeDiagramModule.name,
+  VizGraphDiagramModel.name
 ];
 
 const DiagramsSidebarModule = angular.module('tt2ps.components.chat.diagrams-sidebar', dependencies);

--- a/src/directives/chat/diagrams-sidebar/svg-diagram-manager.js
+++ b/src/directives/chat/diagrams-sidebar/svg-diagram-manager.js
@@ -10,7 +10,7 @@ export class SvgDiagramManager {
      * @param {boolean} [isIframe=false]
      *        Indicates whether `el` is an iframe element.
      */
-    constructor(el, onSVGElementClickCallback = () => {}, isIframe = false) {
+    constructor(el, attributeName,  onSVGElementClickCallback = () => {}, isIframe = false) {
 
         /**
          * @type {HTMLElement|null}
@@ -35,6 +35,11 @@ export class SvgDiagramManager {
          * @private
          */
         this.iframeDoc = null;
+
+        /**
+         * @type {string} attributeName to be used to identify the element of interest.
+         */
+        this.attributeName = attributeName;
 
         this.onSVGElementClick = onSVGElementClickCallback;
 
@@ -118,39 +123,39 @@ export class SvgDiagramManager {
      * @private
      */
     _svgClick(event) {
-        const clickedElementIRI = this._getIRI(event);
-        if (clickedElementIRI && this.onSVGElementClick) {
-            this.onSVGElementClick(clickedElementIRI);
+        const clickedElementValue = this._getAttributeValue(event);
+        if (clickedElementValue && this.onSVGElementClick) {
+            this.onSVGElementClick(clickedElementValue);
         }
     }
 
     /**
-     * Retrieves the `iri` attribute from a target element or its closest parent that has it.
+     * Retrieves the attribute value from a target element or its closest parent that has it.
      *
      * @param {Event | { target: HTMLElement }} element - The event or object containing the target element.
-     * @returns {string | null} The `iri` attribute value, or null if not found.
+     * @returns {string | null} The attribute value, or null if not found.
      */
-    _getIRI(element) {
+    _getAttributeValue(element) {
         if (!element?.target) {
             return null;
         }
 
-        return this._getIRIAttribute(element.target);
+        return this._getValue(element.target);
     }
 
     /**
-     * Recursively retrieves the `iri` attribute from the element or its parent elements.
+     * Recursively retrieves the attribute value from the element or its parent elements.
      *
      * @param {HTMLElement | null} element - The DOM element to check for an `iri` attribute.
      * @returns {string | null} The `iri` attribute value, or null if none is found up the parent chain.
      */
-    _getIRIAttribute(element) {
+    _getValue(element) {
         if (element) {
-            const iri = element.getAttribute('iri');
-            if (iri) {
-                return iri;
+            const attributeValue = element.getAttribute(this.attributeName);
+            if (attributeValue) {
+                return attributeValue;
             }
-            return this._getIRIAttribute(element.parentElement);
+            return this._getValue(element.parentElement);
         }
     }
 

--- a/src/directives/chat/diagrams-sidebar/svg-diagram/svg-diagram.directive.js
+++ b/src/directives/chat/diagrams-sidebar/svg-diagram/svg-diagram.directive.js
@@ -41,7 +41,7 @@ function SvgDiagramDirective(ChatContextService, DiagramService) {
           setTimeout(() => {
             const svgEl = element[0].querySelector('.svg-diagram');
             zoomDiagramHelper = new ZoomDiagramHelper(svgEl);
-            svgDiagramManager = new SvgDiagramManager(svgEl, onDiagramElementClicked);
+            svgDiagramManager = new SvgDiagramManager(svgEl, 'iri', onDiagramElementClicked);
           });
         });
       }

--- a/src/directives/chat/diagrams-sidebar/viz-graph-diagram/viz-graph-diagram.directive.html
+++ b/src/directives/chat/diagrams-sidebar/viz-graph-diagram/viz-graph-diagram.directive.html
@@ -1,0 +1,4 @@
+<iframe ng-if="diagram"
+        ng-src="{{diagram.url | trustAsResourceUrl}}"
+        class="viz-graph-diagram diagram">
+</iframe>

--- a/src/directives/chat/diagrams-sidebar/viz-graph-diagram/viz-graph-diagram.directive.js
+++ b/src/directives/chat/diagrams-sidebar/viz-graph-diagram/viz-graph-diagram.directive.js
@@ -1,17 +1,17 @@
-import './iframe-diagram.directive.scss';
-import template from './iframe-diagram.directive.html';
+import './viz-graph-diagram.directive.scss';
+import template from './viz-graph-diagram.directive.html';
 import {SvgDiagramManager} from "../svg-diagram-manager";
 import {ChatContextEventName} from "../../../../services/chat/chat-context-event-name";
 import {DiagramElementModel} from "../../../../models/chat/diagrams/diagram-element";
 
 const dependencies = [];
 
-const IframeDiagramModule = angular.module('tt2ps.components.chat.iframe-diagram', dependencies);
-IframeDiagramModule.directive('iframeDiagram', IframeDiagramDirective);
+const VizGraphDiagramModel = angular.module('tt2ps.components.chat.viz-graph-diagram', dependencies);
+VizGraphDiagramModel.directive('vizGraphDiagram', VizGraphDiagramDirective);
 
-IframeDiagramDirective.$inject = ['ChatContextService'];
+VizGraphDiagramDirective.$inject = ['ChatContextService'];
 
-function IframeDiagramDirective(ChatContextService) {
+function VizGraphDiagramDirective(ChatContextService) {
     return {
         restrict: 'E',
         scope: {
@@ -20,7 +20,6 @@ function IframeDiagramDirective(ChatContextService) {
         },
         template,
         link: function ($scope, element, attrs) {
-
             let iframe = undefined;
             let svgDiagramManager = undefined;
 
@@ -30,13 +29,13 @@ function IframeDiagramDirective(ChatContextService) {
             const init = () => {
                 // Set time out to be sure the iframe is loaded before we try to access its content
                 setTimeout(() => {
-                    iframe = element[0].querySelector('.iframe-diagram');
-                    svgDiagramManager = new SvgDiagramManager(iframe, 'iri', onDiagramElementClicked, true);
+                    iframe = element[0].querySelector('.viz-graph-diagram');
+                    svgDiagramManager = new SvgDiagramManager(iframe, 'id', onDiagramElementClicked, true);
                 });
             }
 
-            const onDiagramElementClicked = (iri) => {
-                ChatContextService.emit(ChatContextEventName.ASK_FOR_DIAGRAM_ELEMENT, new DiagramElementModel($scope.diagram.type, iri));
+            const onDiagramElementClicked = (id) => {
+                ChatContextService.emit(ChatContextEventName.ASK_FOR_DIAGRAM_ELEMENT, new DiagramElementModel($scope.diagram.type, id));
             }
 
 
@@ -58,4 +57,4 @@ function IframeDiagramDirective(ChatContextService) {
     }
 }
 
-export default IframeDiagramModule;
+export default VizGraphDiagramModel;

--- a/src/directives/chat/diagrams-sidebar/viz-graph-diagram/viz-graph-diagram.directive.scss
+++ b/src/directives/chat/diagrams-sidebar/viz-graph-diagram/viz-graph-diagram.directive.scss
@@ -1,0 +1,4 @@
+.viz-graph-diagram {
+  width: 100%;
+  height: 100%;
+}

--- a/src/models/chat/diagrams/diagram-element.js
+++ b/src/models/chat/diagrams/diagram-element.js
@@ -2,10 +2,10 @@ export class DiagramElementModel {
     /**
      *
      * @param {string} diagramType - the type of diagram this element belongs to (e.g. "svg", "iframe", etc.)
-     * @param elementIRI - the Iri of the element.
+     * @param value - the value of the element.
      */
-    constructor(diagramType, elementIRI) {
+    constructor(diagramType, value) {
         this.diagramType = diagramType;
-        this.elementIRI = elementIRI;
+        this.value = value;
     }
 }

--- a/src/models/chat/diagrams/diagram-types.js
+++ b/src/models/chat/diagrams/diagram-types.js
@@ -1,5 +1,6 @@
 export const DiagramTypes = {
   SVG: 'svg',
   IMAGE: 'image',
-  IFRAME: 'iframe'
+  IFRAME: 'iframe',
+  VIZ_GRAPH: 'vizGraph'
 }

--- a/src/models/chat/diagrams/viz-graph-disgram.js
+++ b/src/models/chat/diagrams/viz-graph-disgram.js
@@ -1,0 +1,3 @@
+import {FrameDiagramModel} from "./frame-diagram";
+
+export class VizGraphDiagramModel extends FrameDiagramModel{}

--- a/src/services/chat/chat.rest.service.fake.backend.js
+++ b/src/services/chat/chat.rest.service.fake.backend.js
@@ -158,7 +158,7 @@ export class ChatRestServiceFakeBackend {
                         type: "iframe",
                         url: "https://images.pexels.com/photos/45201/kitty-cat-kitten-pet-45201.jpeg"
                     }, {
-                        type: "iframe",
+                        type: "vizGraph",
                         url: "images/test/diagram-1.svg"
                     },{
                             type: "svg",

--- a/src/services/chat/mappers/chat-message.mapper.js
+++ b/src/services/chat/mappers/chat-message.mapper.js
@@ -4,6 +4,7 @@ import {DiagramTypes} from '../../../models/chat/diagrams/diagram-types';
 import {ImageDiagramModel} from '../../../models/chat/diagrams/image-diagram';
 import {FrameDiagramModel} from '../../../models/chat/diagrams/frame-diagram';
 import {SvgDiagramModel} from '../../../models/chat/diagrams/svg-diagram';
+import {VizGraphDiagramModel} from "../../../models/chat/diagrams/viz-graph-disgram";
 
 /**
  * Converts the response from the server to a list of ChatMessageModel array.
@@ -64,6 +65,8 @@ export const diagramModelMapper = (data = {}) => {
       return new SvgDiagramModel(data);
       case DiagramTypes.IMAGE:
         return new ImageDiagramModel(data);
+      case DiagramTypes.VIZ_GRAPH:
+          return new VizGraphDiagramModel(data);
     default:
       return new FrameDiagramModel(data);
   }


### PR DESCRIPTION
SN-277: Interaction with PowSyBl and VizGraph Diagrams
## What
Extend the SVG diagram manager with the ability to be configured to use a specific attribute name.

## Why
Currently, we support two diagram rendering options: SVG and VizGraph. Each diagram type uses different attributes to store the required IRI value.

Because of this difference, the manager must be configurable to correctly extract the IRI depending on the diagram type.

## How
Update the diagram manager to accept a configuration parameter that specifies which attribute name to use when retrieving the IRI value of a clicked element.

## Additional work
Fixes https://github.com/statnett/Talk2PowerSystem_PM/issues/305#issuecomment-3971442347