### PR TITLE
Sn 277 fix visgraph click handlers

### DIFF
--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -3,7 +3,7 @@ name: t2ps-chatbot-ui
 description: Web application for the Talk to the Power System Chatbot, served via Nginx Web Server
 type: application
 version: 1.0.3
-appVersion: "v2.0.0-rc5"
+appVersion: "v2.0.0-rc6"
 home: https://github.com/statnett/Talk2PowerSystem_UI
 sources:
   - https://github.com/statnett/Talk2PowerSystem_UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-2-power-system-ui",
-  "version": "2.0.0-rc5",
+  "version": "2.0.0-rc6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-2-power-system-ui",
-      "version": "2.0.0-rc5",
+      "version": "2.0.0-rc6",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/msal-browser": "^4.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk-2-power-system-ui",
-  "version": "2.0.0-rc5",
+  "version": "2.0.0-rc6",
   "description": "The web application for Talk 2 Power System APIs",
   "scripts": {
     "start": "webpack serve --mode development --env baseHref=/",

--- a/src/configurations/project-info.js
+++ b/src/configurations/project-info.js
@@ -1,7 +1,7 @@
 module.exports = {
   "project": {
     "name": "talk-2-power-system-ui",
-    "version": "2.0.0-rc5"
+    "version": "2.0.0-rc6"
   },
   "framework": {
     "name": "AngularJS",

--- a/src/directives/chat/diagrams-sidebar/svg-diagram-manager.js
+++ b/src/directives/chat/diagrams-sidebar/svg-diagram-manager.js
@@ -10,7 +10,7 @@ export class SvgDiagramManager {
      * @param {boolean} [isIframe=false]
      *        Indicates whether `el` is an iframe element.
      */
-    constructor(el, attributeName,  onSVGElementClickCallback = () => {}, isIframe = false) {
+    constructor(el, attributeName,  onSVGElementClickCallback = () => {}, isIframe = false, iframeStyle) {
 
         /**
          * @type {HTMLElement|null}
@@ -25,6 +25,11 @@ export class SvgDiagramManager {
         this.isIframe = isIframe;
 
         /**
+         * @type {string | undefined}
+         */
+        this.iframeStyle = iframeStyle;
+
+        /**
          * @type {SVGSVGElement|null}
          * @private
          */
@@ -35,6 +40,14 @@ export class SvgDiagramManager {
          * @private
          */
         this.iframeDoc = null;
+
+        /**
+         * ID of the interval timer used to repeatedly check for the SVG element.
+         * Stored so it can be cleared when the class instance is destroyed.
+         *
+         * @type {number|null}
+         */
+        this.timerId = null;
 
         /**
          * @type {string} attributeName to be used to identify the element of interest.
@@ -72,17 +85,56 @@ export class SvgDiagramManager {
     }
 
     /**
-     * Searches for an <svg> inside the provided root and attaches click listener if found.
+     * Attempts to locate an <svg> element inside the given root element. Polls periodically until the element is found
+     * or the timeout is reached.
      *
-     * @param {HTMLElement|Document} root
-     * @private
+     * @param {HTMLElement} root - The root element to search within.
+     * @param {number} [maxDuration=10000] - Maximum time in milliseconds to keep searching.
+     * @param {number} [interval=200] - Polling interval in milliseconds.
+     * @returns {Promise<SVGElement>} Resolves with the found SVG element.
+     * @throws {Error} Rejects if no SVG is found within the specified timeout.
+     */
+    _findSvg(root, maxDuration = 4000, interval = 200) {
+        return new Promise((resolve, reject) => {
+            const startTime = Date.now();
+            const check = () => {
+                const svg = root.querySelector("svg");
+
+                if (svg) {
+                    clearInterval(this.timerId);
+                    this.timerId = null;
+                    resolve(svg);
+                    return;
+                }
+
+                if (Date.now() - startTime >= maxDuration) {
+                    clearInterval(this.timerId);
+                    this.timerId = null;
+                    reject(new Error("SVG not found within timeout."));
+                }
+            };
+
+            this.timerId = setInterval(check, interval);
+            // immediate first attempt
+            check();
+        });
+    }
+
+    /**
+     * Initializes the SVG by locating it within the provided root element and attaching the click event handler once available.
+     *
+     * @param {HTMLElement} root - The root element containing the SVG.
+     * @returns {Promise<void>} Resolves when initialization completes.
      */
     _setupSVG(root) {
-        this.svg = root.querySelector("svg");
-
-        if (this.svg) {
-            this.svg.addEventListener("click", this._onSvgClick);
-        }
+        this._findSvg(root)
+            .then(svg => {
+                this.svg = svg;
+                this.svg.addEventListener("click", this._onSvgClick);
+            })
+            .catch(err => {
+                console.warn(err.message);
+            });
     }
 
     /**
@@ -96,7 +148,16 @@ export class SvgDiagramManager {
             return;
         }
 
+        this._addStyleToFrame();
         this._setupSVG(this.iframeDoc);
+    }
+
+    _addStyleToFrame() {
+        if (this.iframeStyle) {
+            const style = document.createElement('style');
+            style.textContent = this.iframeStyle;
+            this.iframeDoc.head?.appendChild(style);
+        }
     }
 
     /**
@@ -173,6 +234,10 @@ export class SvgDiagramManager {
 
         if (this.svg) {
             this.svg.removeEventListener("click", this._onSvgClick);
+        }
+
+        if (this.timerId) {
+            clearInterval(this.timerId);
         }
 
         this.svg = null;

--- a/src/directives/chat/diagrams-sidebar/viz-graph-diagram/viz-graph-diagram.directive.js
+++ b/src/directives/chat/diagrams-sidebar/viz-graph-diagram/viz-graph-diagram.directive.js
@@ -22,6 +22,7 @@ function VizGraphDiagramDirective(ChatContextService) {
         link: function ($scope, element, attrs) {
             let iframe = undefined;
             let svgDiagramManager = undefined;
+            const VIZGRAPH_EMBED_STYLE_OVERRIDE = 'onto-layout.wb-layout.is-embedded {grid-template-columns: 1fr;}';
 
             // =========================
             // Private functions
@@ -30,7 +31,7 @@ function VizGraphDiagramDirective(ChatContextService) {
                 // Set time out to be sure the iframe is loaded before we try to access its content
                 setTimeout(() => {
                     iframe = element[0].querySelector('.viz-graph-diagram');
-                    svgDiagramManager = new SvgDiagramManager(iframe, 'id', onDiagramElementClicked, true);
+                    svgDiagramManager = new SvgDiagramManager(iframe, 'id', onDiagramElementClicked, true, VIZGRAPH_EMBED_STYLE_OVERRIDE);
                 });
             }
 


### PR DESCRIPTION
SN-277: fixes issues with VizGraph
## What
- The VizGraph visualization is not interactable.
- VizGraph is not displayed.

## Why
- The functionality that registers click event listeners on the visual graph does not work properly. At the time the function is called, the visual graph is not yet loaded, and searching for the <svg> element containing the nodes and links returns undefined.
-  There is a styling issue affecting VizGraph when it is rendered in embedded mode. This issue will be resolved in the next GraphDB release.

## How
- The functionality was updated to retry searching for the visual graph every 200ms until it is found, ensuring the click listeners are registered correctly.
 - A style override was added to the VizGraph iframe to fix the visualization. This is a temporary workaround until the new version of GraphDB is released.