### PR TITLE
SN-285 SN-265 ux improvments

### DIFF
--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -3,7 +3,7 @@ name: t2ps-chatbot-ui
 description: Web application for the Talk to the Power System Chatbot, served via Nginx Web Server
 type: application
 version: 1.0.3
-appVersion: "v2.0.0-rc6"
+appVersion: "v2.0.0-rc7"
 home: https://github.com/statnett/Talk2PowerSystem_UI
 sources:
   - https://github.com/statnett/Talk2PowerSystem_UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talk-2-power-system-ui",
-  "version": "2.0.0-rc6",
+  "version": "2.0.0-rc7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "talk-2-power-system-ui",
-      "version": "2.0.0-rc6",
+      "version": "2.0.0-rc7",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/msal-browser": "^4.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk-2-power-system-ui",
-  "version": "2.0.0-rc6",
+  "version": "2.0.0-rc7",
   "description": "The web application for Talk 2 Power System APIs",
   "scripts": {
     "start": "webpack serve --mode development --env baseHref=/",

--- a/src/app.js
+++ b/src/app.js
@@ -31,6 +31,7 @@ import {UserModel} from "./models/security/user";
 import ToastrServiceModule from "./services/toast.service";
 import MainMenuModule from './directives/main-menu/main-menu.directive';
 import LeftSidebarModule from './directives/left-sidebar/left-sidebar.directive';
+import ToggleButtonModule from "./directives/core/toggle-button/toggle-button.directive";
 
 // $translate.instant converts <b> from strings to &lt;b&gt
 // and $sce.trustAsHtml could not recognise that this is valid html
@@ -61,6 +62,7 @@ let dependencies = [
     ToastrServiceModule.name,
     MainMenuModule.name,
     LeftSidebarModule.name,
+    ToggleButtonModule.name
 ];
 
 const TT2PSModule = angular.module('tt2ps', dependencies);

--- a/src/app.js
+++ b/src/app.js
@@ -32,6 +32,7 @@ import ToastrServiceModule from "./services/toast.service";
 import MainMenuModule from './directives/main-menu/main-menu.directive';
 import LeftSidebarModule from './directives/left-sidebar/left-sidebar.directive';
 import ToggleButtonModule from "./directives/core/toggle-button/toggle-button.directive";
+import LocalStorageContextServiceModule from "./services/local-storage/local-storage-context.service";
 
 // $translate.instant converts <b> from strings to &lt;b&gt
 // and $sce.trustAsHtml could not recognise that this is valid html
@@ -62,7 +63,8 @@ let dependencies = [
     ToastrServiceModule.name,
     MainMenuModule.name,
     LeftSidebarModule.name,
-    ToggleButtonModule.name
+    ToggleButtonModule.name,
+    LocalStorageContextServiceModule.name
 ];
 
 const TT2PSModule = angular.module('tt2ps', dependencies);

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -245,7 +245,9 @@
       },
       "close_sidebar": {
         "tooltip": "Hide question list"
-      }
+      },
+      "explain_show_more": "Show more",
+      "explain_show_less": "Show less"
     },
     "placeholder": {
       "ask-input": "Ask anything"

--- a/src/configurations/project-info.js
+++ b/src/configurations/project-info.js
@@ -1,7 +1,7 @@
 module.exports = {
   "project": {
     "name": "talk-2-power-system-ui",
-    "version": "2.0.0-rc6"
+    "version": "2.0.0-rc7"
   },
   "framework": {
     "name": "AngularJS",

--- a/src/directives/chat/chat-item-details/chat-item-detail.directive.html
+++ b/src/directives/chat/chat-item-details/chat-item-detail.directive.html
@@ -64,7 +64,14 @@
                          class="explain-response">
                         {{ 'chat_panel.labels.explain_no_methods' | translate }}
                     </div>
-                    <div ng-if="explainResponseModel[answer.id].queryMethods.items"
+                    <div class="explain-advanced" ng-if="explainResponseModel[answer.id].queryMethods.items.length">
+                        <toggle-button
+                                active="explainResponseModel[answer.id].showAdvanced"
+                                tooltip="{{(explainResponseModel[answer.id].showAdvanced ? 'chat_panel.btn.explain_show_less' : 'chat_panel.btn.explain_show_more') | translate}}"
+                                ng-click="toggleExplainAdvanced(answer)">
+                        </toggle-button>
+                    </div>
+                    <div ng-if="explainResponseModel[answer.id].queryMethods.items && explainResponseModel[answer.id].showAdvanced || !queryMethod.advanced"
                          class="explain-response"
                          ng-repeat="queryMethod in explainResponseModel[answer.id].queryMethods.items">
                         <div class="explain-call">
@@ -88,7 +95,7 @@
                             <div class="query">
                                 <pre ng-if="queryMethod.query"><code>{{queryMethod.query}}</code></pre>
                             </div>
-                            <div ng-if="queryMethod.args" class="raw-query">
+                            <div ng-if="queryMethod.args && (explainResponseModel[answer.id].showAdvanced || !queryMethod.hideArgs)" class="raw-query">
                                 <span class="label">{{'chat_panel.labels.args' | translate}}:</span>
                                 <markdown-content class="content" content="{{queryMethod.args}}" options="markdownContentOptions"></markdown-content>
                                 <copy-to-clipboard class="copy-to-clipboard-btn" tooltip-text="chat_panel.btn.copy_raw_query.tooltip"

--- a/src/directives/chat/chat-item-details/chat-item-detail.directive.html
+++ b/src/directives/chat/chat-item-details/chat-item-detail.directive.html
@@ -78,7 +78,7 @@
                                 <div ng-if="queryMethod.query" class="actions">
                                     <open-in-sparql-editor
                                         ng-if="queryMethod.queryType === ExplainQueryType.SPARQL"
-                                        repository-id="{{repositoryId}}"
+                                        repository-id="{{queryMethod.repositoryId}}"
                                         query="{{queryMethod.query}}">
                                     </open-in-sparql-editor>
                                     <copy-to-clipboard tooltip-text="chat_panel.btn.copy_{{ queryMethod.queryType }}.tooltip"

--- a/src/directives/chat/chat-item-details/chat-item-detail.directive.html
+++ b/src/directives/chat/chat-item-details/chat-item-detail.directive.html
@@ -66,12 +66,12 @@
                     </div>
                     <div class="explain-advanced" ng-if="explainResponseModel[answer.id].queryMethods.items.length">
                         <toggle-button
-                                active="explainResponseModel[answer.id].showAdvanced"
-                                tooltip="{{(explainResponseModel[answer.id].showAdvanced ? 'chat_panel.btn.explain_show_less' : 'chat_panel.btn.explain_show_more') | translate}}"
-                                ng-click="toggleExplainAdvanced(answer)">
+                                active="explainResponseAdvancedMode"
+                                tooltip="{{(explainResponseAdvancedMode ? 'chat_panel.btn.explain_show_less' : 'chat_panel.btn.explain_show_more') | translate}}"
+                                ng-click="toggleExplainAdvanced()">
                         </toggle-button>
                     </div>
-                    <div ng-if="explainResponseModel[answer.id].queryMethods.items && explainResponseModel[answer.id].showAdvanced || !queryMethod.advanced"
+                    <div ng-if="explainResponseModel[answer.id].queryMethods.items && explainResponseAdvancedMode || !queryMethod.advanced"
                          class="explain-response"
                          ng-repeat="queryMethod in explainResponseModel[answer.id].queryMethods.items">
                         <div class="explain-call">
@@ -95,7 +95,7 @@
                             <div class="query">
                                 <pre ng-if="queryMethod.query"><code>{{queryMethod.query}}</code></pre>
                             </div>
-                            <div ng-if="queryMethod.args && (explainResponseModel[answer.id].showAdvanced || !queryMethod.hideArgs)" class="raw-query">
+                            <div ng-if="queryMethod.args && (explainResponseAdvancedMode || !queryMethod.hideArgs)" class="raw-query">
                                 <span class="label">{{'chat_panel.labels.args' | translate}}:</span>
                                 <markdown-content class="content" content="{{queryMethod.args}}" options="markdownContentOptions"></markdown-content>
                                 <copy-to-clipboard class="copy-to-clipboard-btn" tooltip-text="chat_panel.btn.copy_raw_query.tooltip"

--- a/src/directives/chat/chat-item-details/chat-item-detail.directive.js
+++ b/src/directives/chat/chat-item-details/chat-item-detail.directive.js
@@ -131,6 +131,10 @@ function ChatItemDetailDirective(toastr, $translate, ChatContextService, ChatSer
                 }
             }
 
+            $scope.toggleExplainAdvanced = (answer) => {
+                $scope.explainResponseModel[answer.id]?.toggleAdvanced();
+            }
+
             // =========================
             // Private functions
             // =========================

--- a/src/directives/chat/chat-item-details/chat-item-detail.directive.js
+++ b/src/directives/chat/chat-item-details/chat-item-detail.directive.js
@@ -16,7 +16,7 @@ const ChatItemDetailModule = angular
     .module('tt2ps.directives.chat.chat-item-detail', modules)
     .directive('chatItemDetail', ChatItemDetailDirective);
 
-ChatItemDetailDirective.$inject = ['ToastrService', '$translate', 'ChatContextService', 'ChatService', '$filter'];
+ChatItemDetailDirective.$inject = ['ToastrService', '$translate', 'ChatContextService', 'ChatService', 'LocalStorageContextService'];
 
 /**
  * @ngdoc directive
@@ -29,7 +29,7 @@ ChatItemDetailDirective.$inject = ['ToastrService', '$translate', 'ChatContextSe
  * @example
  * <chat-item-detail chat-item-details="chatItemDetail"></chat-item-detail>
  */
-function ChatItemDetailDirective(toastr, $translate, ChatContextService, ChatService, $filter) {
+function ChatItemDetailDirective(toastr, $translate, ChatContextService, ChatService, LocalStorageContextService) {
     return {
         restrict: 'E',
         template,
@@ -49,6 +49,7 @@ function ChatItemDetailDirective(toastr, $translate, ChatContextService, ChatSer
 
             $scope.ExplainQueryType = ExplainQueryType;
             $scope.markdownContentOptions = undefined;
+            $scope.explainResponseAdvancedMode = false;
 
             /**
              * @type {{[key: string]: ExplainResponseModel}}
@@ -131,8 +132,8 @@ function ChatItemDetailDirective(toastr, $translate, ChatContextService, ChatSer
                 }
             }
 
-            $scope.toggleExplainAdvanced = (answer) => {
-                $scope.explainResponseModel[answer.id]?.toggleAdvanced();
+            $scope.toggleExplainAdvanced = () => {
+                LocalStorageContextService.updateExplainResponseAdvancedMode(!$scope.explainResponseAdvancedMode)
             }
 
             // =========================
@@ -146,6 +147,10 @@ function ChatItemDetailDirective(toastr, $translate, ChatContextService, ChatSer
             const onExplainResponseCacheUpdated = () => {
                 updateExplainResponseModel();
             };
+
+            const onExplainResponseAdvancedModeChanged = (explainResponseAdvancedMode) => {
+                $scope.explainResponseAdvancedMode = explainResponseAdvancedMode;
+            }
 
             const updateExplainResponseModel = () => {
                 $scope.chatItemDetail.answers.forEach((answer) => {
@@ -163,6 +168,7 @@ function ChatItemDetailDirective(toastr, $translate, ChatContextService, ChatSer
             };
 
             subscriptions.push(ChatContextService.onExplainResponseCacheUpdated(onExplainResponseCacheUpdated));
+            subscriptions.push(LocalStorageContextService.onExplainResponseAdvancedModeChanged(onExplainResponseAdvancedModeChanged));
 
             // Deregister the watcher when the scope/directive is destroyed
             $scope.$on('$destroy', removeAllSubscribers);

--- a/src/directives/chat/chat-item-details/chat-item-details.directive.scss
+++ b/src/directives/chat/chat-item-details/chat-item-details.directive.scss
@@ -56,6 +56,10 @@
       margin-left: -0.4em;
     }
 
+    .explain-advanced {
+      text-align: end;
+    }
+
     .derived-answer-hint {
       display: flex;
       flex-wrap: wrap;

--- a/src/directives/core/open-in-sparql-editor/open-in-sparql-editor.directive.html
+++ b/src/directives/core/open-in-sparql-editor/open-in-sparql-editor.directive.html
@@ -1,5 +1,5 @@
 <a class="btn btn-link btn-sm open-in-sparql-editor-btn"
-   href="graphdb/sparql?query={{encodedQuery}}&execute={{executeQuery}}"
+   href="graphdb/sparql?repositoryId={{repositoryId}}&query={{encodedQuery}}&execute={{executeQuery}}"
    target="_blank"
    tt2ps-tooltip="{{'chat_panel.btn.open_in_sparql_editor.tooltip' | translate}}">
     <sparql-icon></sparql-icon>

--- a/src/directives/core/open-in-sparql-editor/open-in-sparql-editor.directive.js
+++ b/src/directives/core/open-in-sparql-editor/open-in-sparql-editor.directive.js
@@ -42,12 +42,17 @@ function OpenInSparqlEditorDirective() {
         restrict: 'E',
         scope: {
             query: '@',
-            executeQuery: '@'
+            executeQuery: '@',
+            repositoryId: '@'
         },
         link: function($scope) {
             if (!$scope.executeQuery) {
                 $scope.executeQuery = false;
             }
+            if (!$scope.repositoryId) {
+                $scope.repositoryId = '';
+            }
+            console.log($scope.repositoryId);
             $scope.encodedQuery = encodeURIComponent($scope.query);
         }
     };

--- a/src/directives/core/open-in-sparql-editor/open-in-sparql-editor.directive.js
+++ b/src/directives/core/open-in-sparql-editor/open-in-sparql-editor.directive.js
@@ -52,7 +52,6 @@ function OpenInSparqlEditorDirective() {
             if (!$scope.repositoryId) {
                 $scope.repositoryId = '';
             }
-            console.log($scope.repositoryId);
             $scope.encodedQuery = encodeURIComponent($scope.query);
         }
     };

--- a/src/directives/core/toggle-button/toggle-button.directive.html
+++ b/src/directives/core/toggle-button/toggle-button.directive.html
@@ -1,0 +1,5 @@
+<button
+        class="toggle-switch"
+        tt2ps-tooltip="{{tooltip}}">
+    <div class="handle"></div>
+</button>

--- a/src/directives/core/toggle-button/toggle-button.directive.js
+++ b/src/directives/core/toggle-button/toggle-button.directive.js
@@ -1,0 +1,69 @@
+import './toggle-button.directive.scss';
+import template from './toggle-button.directive.html';
+
+const dependencies = [];
+const ToggleButtonModule = angular.module('tt2ps.directives.core.toggle-button', dependencies);
+
+ToggleButtonModule.directive('toggleButton', ToggleButton);
+
+ToggleButton.$inject = [];
+
+/**
+ * Directive: toggleButton
+ *
+ * Scope bindings:
+ *  - active: two-way binding, boolean, whether the toggle is active
+ *  - tooltip: string, the text to show on hover
+ *
+ * @returns {object} AngularJS directive definition object
+ */
+function ToggleButton() {
+    return {
+        restrict: 'E',
+        template,
+        scope: {
+            active: '=',
+            tooltip: '@',
+        },
+        link: function (scope, element) {
+            const unsubscribes = [];
+
+            const init = () => {
+                // Select the toggle switch element inside the directive
+                let toggleButton = angular.element(element[0].querySelector('.toggle-switch'));
+                if (!toggleButton) {
+                    return;
+                }
+
+                // Watch the 'active' state and toggle the CSS class
+                unsubscribes.push(scope.$watch('active', (newVal) => {
+                    toggleButton.toggleClass('active', !!newVal);
+                }));
+
+                // Tooltips in AngularJS often only render when a mouseenter event occurs. If the tooltip text changes
+                // while the user is already hovering over the element, the tooltip does not automatically refresh.
+                // To force the tooltip to update, we simulate a `mouseleave` followed by a `mouseenter`. This destroys
+                // the old tooltip and recreates it with the new text.
+                // Watch the tooltip text and force tooltip refresh on change
+                unsubscribes.push(scope.$watch('tooltip', () => {
+                    // Trigger 'mouseleave' to destroy the old tooltip
+                    toggleButton.triggerHandler('mouseleave');
+                    // Delay a little to allow tooltip destruction, then trigger 'mouseenter'
+                    // to recreate the tooltip with the updated text
+                    setTimeout(() => {
+                        toggleButton.triggerHandler('mouseenter');
+                    });
+                }));
+            }
+
+            // Cleanup watchers when the element is destroyed
+            element.on('$destroy', () => {
+                unsubscribes.forEach(unsubscribe => unsubscribe());
+            });
+
+            init();
+        }
+    };
+}
+
+export default ToggleButtonModule;

--- a/src/directives/core/toggle-button/toggle-button.directive.scss
+++ b/src/directives/core/toggle-button/toggle-button.directive.scss
@@ -1,0 +1,32 @@
+.toggle-switch {
+  width: 30px;
+  height: 17px;
+  background-color: #ccc;
+  border-radius: 34px;
+  border: none;
+  position: relative;
+  cursor: pointer;
+  outline: none;
+  transition: background-color 0.3s;
+  padding: 0;
+}
+
+.toggle-switch .handle {
+  width: 13px;
+  height: 13px;
+  background-color: #fff;
+  border-radius: 50%;
+  position: absolute;
+  top: 2px;
+  left: 4px;
+  transition: transform 0.3s;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.toggle-switch.active {
+  background-color: var(--gw-primary-color);
+}
+
+.toggle-switch.active .handle {
+  transform: translateX(10px);
+}

--- a/src/models/chat/explain-query-method.js
+++ b/src/models/chat/explain-query-method.js
@@ -15,6 +15,10 @@ export class ExplainQueryMethodModel {
          */
         this._repositoryId = data.graphdbRepositoryId || '';
 
+        this._advanced = data.advanced || false;
+
+        this._hideArgs = data.hideArgs || false;
+
         /**
          * @type {string}
          */
@@ -93,5 +97,21 @@ export class ExplainQueryMethodModel {
 
     set errorMessage(value) {
         this._errorMessage = value;
+    }
+
+    get advanced() {
+        return this._advanced;
+    }
+
+    set advanced(value) {
+        this._advanced = value;
+    }
+
+    get hideArgs() {
+        return this._hideArgs;
+    }
+
+    set hideArgs(value) {
+        this._hideArgs = value;
     }
 }

--- a/src/models/chat/explain-query-method.js
+++ b/src/models/chat/explain-query-method.js
@@ -13,6 +13,11 @@ export class ExplainQueryMethodModel {
         /**
          * @type {string}
          */
+        this._repositoryId = data.graphdbRepositoryId || '';
+
+        /**
+         * @type {string}
+         */
         this._query = data.query;
 
         /**
@@ -56,6 +61,14 @@ export class ExplainQueryMethodModel {
 
     set args(value) {
         this._args = value;
+    }
+
+    get repositoryId() {
+        return this._repositoryId;
+    }
+
+    set repositoryId(value) {
+        this._repositoryId = value;
     }
 
     get query() {

--- a/src/models/chat/explain-response.js
+++ b/src/models/chat/explain-response.js
@@ -17,12 +17,6 @@ export class ExplainResponseModel {
         this._queryMethods = data.queryMethods;
 
         this._expanded = data.expanded !== undefined ? data.expanded : true;
-
-        this._showAdvanced = false;
-    }
-
-    toggleAdvanced() {
-        this._showAdvanced = !this._showAdvanced;
     }
 
     get chatId() {
@@ -55,13 +49,5 @@ export class ExplainResponseModel {
 
     set expanded(value) {
         this._expanded = value;
-    }
-
-    get showAdvanced() {
-        return this._showAdvanced;
-    }
-
-    set showAdvanced(value) {
-        this._showAdvanced = value;
     }
 }

--- a/src/models/chat/explain-response.js
+++ b/src/models/chat/explain-response.js
@@ -17,6 +17,12 @@ export class ExplainResponseModel {
         this._queryMethods = data.queryMethods;
 
         this._expanded = data.expanded !== undefined ? data.expanded : true;
+
+        this._showAdvanced = false;
+    }
+
+    toggleAdvanced() {
+        this._showAdvanced = !this._showAdvanced;
     }
 
     get chatId() {
@@ -49,5 +55,13 @@ export class ExplainResponseModel {
 
     set expanded(value) {
         this._expanded = value;
+    }
+
+    get showAdvanced() {
+        return this._showAdvanced;
+    }
+
+    set showAdvanced(value) {
+        this._showAdvanced = value;
     }
 }

--- a/src/models/local-storage/local-storage-key.js
+++ b/src/models/local-storage/local-storage-key.js
@@ -1,0 +1,3 @@
+export const LOCAL_STORAGE_KEY = {
+    EXPLAIN_RESPONSE_MODE: 't2ps.explainResponseMode',
+}

--- a/src/models/tt2ps-event-name.js
+++ b/src/models/tt2ps-event-name.js
@@ -21,5 +21,10 @@ export const TT2PSEventName = {
     /**
      * Emitted when the components information has changed.
      */
-    COMPONENTS_INFO_CHANGED: 'componentsInfoChanged'
+    COMPONENTS_INFO_CHANGED: 'componentsInfoChanged',
+
+    /**
+     * Emitted when the explain response advanced mode flag has changed.
+     */
+    EXPLAIN_RESPONSE_ADVANCED_MODE_CHANGED: 'explainResponseAdvancedModeChanged'
 };

--- a/src/services/chat/chat.rest.service.fake.backend.js
+++ b/src/services/chat/chat.rest.service.fake.backend.js
@@ -218,18 +218,21 @@ export class ChatRestServiceFakeBackend {
                     args: "SELECT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
                     query: "SELEdCT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
                     queryType: "sparql",
+                    graphdbRepositoryId: "cim",
                     errorOutput: null
                 }, {
                     name: "sample_sparql_queries",
                     args: "SELECT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
                     query: "SELEdCT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
                     queryType: "sparql",
+                    graphdbRepositoryId: "qa_dataset",
                     errorOutput: null
                 }, {
                     name: "retrieve_time_series",
                     args: "SELECT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
                     query: "SELEdCT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
                     queryType: "sparql",
+                    graphdbRepositoryId: "cim",
                     errorOutput: null
                 }, {
                     name: "retrieve_data_points",

--- a/src/services/chat/chat.rest.service.fake.backend.js
+++ b/src/services/chat/chat.rest.service.fake.backend.js
@@ -219,6 +219,8 @@ export class ChatRestServiceFakeBackend {
                     query: "SELEdCT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
                     queryType: "sparql",
                     graphdbRepositoryId: "cim",
+                    advanced: true,
+                    hideArgs: true,
                     errorOutput: null
                 }, {
                     name: "sample_sparql_queries",
@@ -226,6 +228,7 @@ export class ChatRestServiceFakeBackend {
                     query: "SELEdCT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
                     queryType: "sparql",
                     graphdbRepositoryId: "qa_dataset",
+                    hideArgs: true,
                     errorOutput: null
                 }, {
                     name: "retrieve_time_series",
@@ -233,12 +236,14 @@ export class ChatRestServiceFakeBackend {
                     query: "SELEdCT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
                     queryType: "sparql",
                     graphdbRepositoryId: "cim",
+                    advanced: true,
                     errorOutput: null
                 }, {
                     name: "retrieve_data_points",
                     args: "SELECT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
                     query: "SELEdCT ?character ?height WHERE { ?character voc:height ?height . FILTER (?character = <https://swapi.co/resource/human/1> || ?character = <https://swapi.co/resource/human/5>) }",
                     queryType: "sparql",
+                    advanced: true,
                     errorOutput: null
                 },
                 {
@@ -259,6 +264,7 @@ export class ChatRestServiceFakeBackend {
                     args: "{\"queries\":[{\"query\":\"pilots that work with Luke Skywalker\",\"filter\":{\"document_id\":\"https://swapi.co/resource/human/1\"},\"top_k\":3}]}",
                     query: "{\n  \"queries\" : [ {\n    \"query\" : \"pilots that work with Luke Skywalker\",\n    \"filter\" : {\n      \"document_id\" : \"https://swapi.co/resource/human/1\"\n    },\n    \"top_k\" : 3\n  } ]\n}",
                     queryType: "json",
+                    advanced: true,
                     errorOutput: null
                 },
                 {
@@ -266,6 +272,7 @@ export class ChatRestServiceFakeBackend {
                     args: "Luke Skywalker",
                     query: "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nPREFIX skos: <http://www.w3.org/2004/02/skos/core#>\nPREFIX onto: <http://www.ontotext.com/>\nSELECT ?label ?iri {\n    ?label onto:fts ('''Luke~ Skywalker~''' '*') .\n    ?iri rdfs:label|skos:prefLabel ?label .\n}",
                     queryType: "sparql",
+                    advanced: true,
                     errorOutput: null
                 },
                 {
@@ -287,18 +294,21 @@ export class ChatRestServiceFakeBackend {
                     args: 'Second Luke',
                     query: 'PREFIX onto: <http://www.ontotext.com/>\nDESCRIBE ?iri {\n\t?x onto:fts \'\'\'Second Luke\'\'\' .\n\t{\n\t\t?x ?p ?iri .\n\t} union {\n\t\t?iri ?p ?x .\n\t}\n}',
                     queryType: "sparql",
+                    advanced: true,
                     errorOutput: null
                 }, {
                     name: 'similarity_search',
                     args: 'Second Luke',
                     query: 'PREFIX onto: <http://www.ontotext.com/>\nDESCRIBE ?iri {\n\t?x onto:fts \'\'\'Second Luke\'\'\' .\n\t{\n\t\t?x ?p ?iri .\n\t} union {\n\t\t?iri ?p ?x .\n\t}\n}',
                     queryType: "sparql",
+                    advanced: true,
                     errorOutput: null
                 }, {
                     name: "iri_discovery",
                     args: "Luke Skywalker",
                     query: "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nPREFIX skos: <http://www.w3.org/2004/02/skos/core#>\nPREFIX onto: <http://www.ontotext.com/>\nSELECT ?label ?iri {\n    ?label onto:fts ('''Luke~ Skywalker~''' '*') .\n    ?iri rdfs:label|skos:prefLabel ?label .\n}",
                     queryType: "sparql",
+                    advanced: true,
                     errorOutput: null
                 }, {
                     name: "sparql_query",

--- a/src/services/local-storage/local-storage-context.service.js
+++ b/src/services/local-storage/local-storage-context.service.js
@@ -1,0 +1,118 @@
+import {cloneDeep} from 'lodash';
+import {TT2PSEventName} from "../../models/tt2ps-event-name";
+import LocalStorageServiceModule from "./local-storage.service";
+import {LOCAL_STORAGE_KEY} from "../../models/local-storage/local-storage-key";
+
+const dependencies = [
+    LocalStorageServiceModule.name
+];
+
+const LocalStorageContextServiceModule = angular.module('tt2ps.services.local-storage-context-service', dependencies);
+
+LocalStorageContextServiceModule.factory('LocalStorageContextService', LocalStorageContextService);
+
+LocalStorageContextService.$inject = ['$window', '$rootScope', 'EventEmitterService', 'LocalStorageService'];
+
+function LocalStorageContextService($window, $rootScope, EventEmitterService, LocalStorageService) {
+
+    /**
+     * Initializes the service.
+     * Registers listeners required for cross-tab synchronization.
+     * @private
+     */
+    const _init = () => {
+        _registerExplainResponseModeStorageListener();
+    };
+
+    /**
+     * Returns the explain response advanced mode flag.
+     *
+     * @return {boolean} explainResponseAdvancedMode Flag indicating whether the explain response advanced mode is enabled.
+     */
+    const getExplainResponseAdvancedMode = () => {
+        return LocalStorageService.get(LOCAL_STORAGE_KEY.EXPLAIN_RESPONSE_MODE) === 'true';
+    };
+
+    /**
+     * Updates the explain response advanced mode flag and emits an event notifying listeners that the value has changed.
+     *
+     * @param {boolean} explainResponseAdvancedMode Flag indicating whether the explain response advanced mode is enabled.
+     */
+    const updateExplainResponseAdvancedMode = (explainResponseAdvancedMode) => {
+        LocalStorageService.set(LOCAL_STORAGE_KEY.EXPLAIN_RESPONSE_MODE, explainResponseAdvancedMode);
+        _notifyExplainResponseAdvancedModeChanged();
+    };
+
+    /**
+     * Subscribes to the explain response advanced mode change event. The callback is immediately invoked with
+     * the current value.
+     *
+     * @param {function(boolean):void} callback Callback invoked when the value changes.
+     * @return {function} Function that unsubscribes the listener.
+     */
+    const onExplainResponseAdvancedModeChanged = (callback) => {
+        if (angular.isFunction(callback)) {
+            callback(getExplainResponseAdvancedMode());
+        }
+
+        return subscribe(TT2PSEventName.EXPLAIN_RESPONSE_ADVANCED_MODE_CHANGED, (mode) => callback(mode));
+    };
+
+    /**
+     * Emits an application event using EventEmitterService with a deep-cloned payload.
+     *
+     * @param {string} tT2PSEventName Event name defined in {@link TT2PSEventName}.
+     * @param {*} payload Payload to emit with the event.
+     */
+    const emit = (tT2PSEventName, payload) => {
+        EventEmitterService.emitSync(tT2PSEventName, cloneDeep(payload));
+    };
+
+    /**
+     * Subscribes to an application event.
+     *
+     * @param {string} tT2PSEventName Event name defined in {@link TT2PSEventName}.
+     * @param {function(*):void} callback Function invoked when the event is emitted.
+     * @return {function} Function used to unsubscribe from the event.
+     */
+    const subscribe = (tT2PSEventName, callback) => {
+        return EventEmitterService.subscribeSync(tT2PSEventName, (payload) => callback(payload));
+    };
+
+    /**
+     * Emits an event indicating that the explain response advanced mode has changed.
+     *
+     * @private
+     */
+    const _notifyExplainResponseAdvancedModeChanged = () => {
+        emit(TT2PSEventName.EXPLAIN_RESPONSE_ADVANCED_MODE_CHANGED, getExplainResponseAdvancedMode());
+    };
+
+    /**
+     * Registers a browser storage event listener to detect updates to the explain response advanced mode key
+     * from other browser tabs.
+     *
+     * @private
+     */
+    const _registerExplainResponseModeStorageListener = () => {
+        $window.addEventListener('storage', (event) => {
+            if (LOCAL_STORAGE_KEY.EXPLAIN_RESPONSE_MODE === event.key) {
+                $rootScope.$applyAsync(function () {
+                    _notifyExplainResponseAdvancedModeChanged();
+                });
+            }
+        });
+    };
+
+    _init();
+
+    return {
+        emit,
+        subscribe,
+        getExplainResponseAdvancedMode,
+        updateExplainResponseAdvancedMode,
+        onExplainResponseAdvancedModeChanged
+    };
+}
+
+export default LocalStorageContextServiceModule;

--- a/src/services/local-storage/local-storage.service.js
+++ b/src/services/local-storage/local-storage.service.js
@@ -1,0 +1,39 @@
+const LocalStorageServiceModule = angular.module('tt2ps.services.local-storage-service', []);
+LocalStorageServiceModule.factory('LocalStorageService', LocalStorageService);
+
+LocalStorageService.$inject = ['$window'];
+
+/**
+ * LocalStorage service wrapper.
+ * Provides simple access to browser localStorage.
+ */
+function LocalStorageService($window) {
+
+    /**
+     * Retrieves a value from localStorage.
+     *
+     * @param {string} key LocalStorage key.
+     * @param {string} [defaultValue] Value returned if the key does not exist.
+     * @returns {string|null} Stored value or default value.
+     */
+    const get = (key, defaultValue) => {
+        return $window.localStorage.getItem(key) || defaultValue;
+    }
+
+    /**
+     * Stores a value in localStorage.
+     *
+     * @param {string} key LocalStorage key.
+     * @param {string} value Value to store.
+     */
+    const set = (key, value) => {
+        $window.localStorage.setItem(key, value);
+    }
+
+    return {
+        get,
+        set
+    };
+}
+
+export default LocalStorageServiceModule;


### PR DESCRIPTION
## What
- SN-285: Some of the links that open the Workbench SPARQL editor are not working.
- SN-265: Added the ability to show or hide some of the query methods used by the LLM to generate the response.

## Why
- The results of the SPARQL query depend on the selected repository in the Workbench. Previously, we did not send the repository ID because the Workbench implementation did not support changing the selected repository through a URL parameter.
- Currently, all extraction methods are displayed when the user clicks the "Explain Response" button. However, most users are only interested in the final SPARQL query.

## How
- With the newer version of GraphDB, the Workbench now supports changing the selected repository via a URL parameter. Therefore, the open-in-sparql-editor directive has been extended to send the repository parameter.
- The backend API has been extended to include additional information about extraction methods, including a flag indicating which methods are advanced. The UI has been updated with a toggle button that allows users to show more or less "Explain Response" information.